### PR TITLE
Typings: use Renderers for renderers of ReactMarkdownProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ declare namespace ReactMarkdown {
     readonly transformLinkUri?: (uri: string, children?: ReactNode, title?: string) => string
     readonly transformImageUri?: (uri: string, children?: ReactNode, title?: string, alt?: string) => string
     readonly unwrapDisallowed?: boolean
-    readonly renderers?: {[nodeType: string]: ReactType}
+    readonly renderers?: Renderers
     readonly astPlugins?: MdastPlugin[]
     readonly plugins?: any[] | (() => void)
   }


### PR DESCRIPTION
I think `renderers` of `ReactMarkdownProps` should use interface `Renderers`