### PR TITLE
Better type definitions for `renderers` prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -88,7 +88,7 @@ declare namespace ReactMarkdown {
     readonly transformLinkUri?: ((uri: string, children?: ReactNode, title?: string) => string) | null
     readonly transformImageUri?: ((uri: string, children?: ReactNode, title?: string, alt?: string) => string) | null
     readonly unwrapDisallowed?: boolean
-    readonly renderers?: {[nodeType: string]: ReactType}
+    readonly renderers?: Partial<Record<NodeType, ReactType>>
     readonly astPlugins?: MdastPlugin[]
     readonly plugins?: any[] | (() => void)
     readonly parserOptions?: Partial<RemarkParseOptions>


### PR DESCRIPTION
Currently, `renderers` prop object keys are expanded to string, which can cause bugs if the user types the wrong NodeType as a key.
Using `Record<NodeType, ReactType>`, the object's keys must be valid `NodeType`. `Partial` is needed to allow for partial renderer override.