### PR TITLE
Add rel tag to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ this is a Good Thing™.
   `allowedTypes` (or specified as a `disallowedType`), it won't be included. The function will
   receive three arguments argument (`node`, `index`, `parent`), where `node` contains different
   properties depending on the node type.
+- `linkRel` - _function|string_ Sets the default rel attribute for links. If a function is
+  provided, it will be called with `url`, `text`, and `title` and should return a string
+  (e.g. `noopener`). Default is `undefined` (no rel attribute).
 - `linkTarget` - _function|string_ Sets the default target attribute for links. If a function is
   provided, it will be called with `url`, `text`, and `title` and should return a string
   (e.g. `_blank` for a new tab). Default is `undefined` (no target attribute).

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,6 +71,7 @@ declare namespace ReactMarkdown {
     | "collapsed"
     | "full"
 
+  export type LinkRelResolver = (uri: string, text: string, title?: string) => string
   export type LinkTargetResolver = (uri: string, text: string, title?: string) => string
 
   export interface ReactMarkdownProps {
@@ -84,6 +85,7 @@ declare namespace ReactMarkdown {
     readonly allowNode?: (node: MarkdownAbstractSyntaxTree, index: number, parent: NodeType) => boolean
     readonly allowedTypes?: NodeType[]
     readonly disallowedTypes?: NodeType[]
+    readonly linkRel?: string | LinkRelResolver
     readonly linkTarget?: string | LinkTargetResolver
     readonly transformLinkUri?: ((uri: string, children?: ReactNode, title?: string) => string) | null
     readonly transformImageUri?: ((uri: string, children?: ReactNode, title?: string, alt?: string) => string) | null

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -115,7 +115,11 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
             : opts.linkTarget,
         href: opts.transformLinkUri
           ? opts.transformLinkUri(node.url, node.children, node.title)
-          : node.url
+          : node.url,
+        rel:
+          typeof opts.linkRel === 'function'
+            ? opts.linkRel(node.url, node.children, node.title)
+            : opts.linkRel,
       })
       break
     case 'image':

--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -34,7 +34,7 @@ const ReactMarkdown = function ReactMarkdown(props) {
     renderers: renderers,
     definitions: getDefinitions(rawAst)
   })
-  
+
   const astPlugins = determineAstPlugins(props)
   // eslint-disable-next-line no-sync
   const transformedAst = parser.runSync(rawAst)
@@ -103,6 +103,7 @@ ReactMarkdown.propTypes = {
   allowedTypes: PropTypes.arrayOf(PropTypes.oneOf(allTypes)),
   disallowedTypes: PropTypes.arrayOf(PropTypes.oneOf(allTypes)),
   transformLinkUri: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+  linkRel: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   linkTarget: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   transformImageUri: PropTypes.func,
   astPlugins: PropTypes.arrayOf(PropTypes.func),

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -1383,6 +1383,19 @@ exports[`should be able to render replaced non-void html elements with HTML pars
 </p>
 `;
 
+exports[`should call function to get rel attribute for links if specified 1`] = `
+<p>
+  This is 
+  <a
+    href="https://espen.codes/"
+    rel="noopener"
+  >
+    a link
+  </a>
+   to Espen.Codes.
+</p>
+`;
+
 exports[`should call function to get target attribute for links if specified 1`] = `
 <p>
   This is 
@@ -2127,6 +2140,19 @@ exports[`should unwrap child nodes from disallowed nodes, if unwrapDisallowed op
    had the initial commit
   , but has had several 
   contributors
+</p>
+`;
+
+exports[`should use rel attribute for links if specified 1`] = `
+<p>
+  This is 
+  <a
+    href="https://espen.codes/"
+    rel="noopener"
+  >
+    a link
+  </a>
+   to Espen.Codes.
 </p>
 `;
 

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -90,6 +90,19 @@ test('should call function to get target attribute for links if specified', () =
   expect(component.toJSON()).toMatchSnapshot()
 })
 
+test('should use rel attribute for links if specified', () => {
+  const input = 'This is [a link](https://espen.codes/) to Espen.Codes.'
+  const component = renderer.create(<Markdown linkRel="noopener" source={input} />)
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
+test('should call function to get rel attribute for links if specified', () => {
+  const input = 'This is [a link](https://espen.codes/) to Espen.Codes.'
+  const getRel = uri => (uri.match(/^http/) ? 'noopener' : undefined)
+  const component = renderer.create(<Markdown linkRel={getRel} source={input} />)
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
 test('should handle images without title attribute', () => {
   const input = 'This is ![an image](/ninja.png).'
   const component = renderer.create(<Markdown source={input} />)
@@ -812,7 +825,7 @@ test('should render table of contents plugin', () => {
     '### Subsection',
     '## Third Section'
   ].join('\n')
-  
+
   const component = renderer.create(<Markdown source={input} plugins={[toc]} />)
   expect(component.toJSON()).toMatchSnapshot()
 })


### PR DESCRIPTION
Hi,

For security reasons external links should be able to have a `rel` tag (.e.g. "noopener noreferrer"). More info [here](https://mathiasbynens.github.io/rel-noopener/)

I created a `linkRel` option to add the tag, similar to `linkTarget`

This is the first year I participate in the Hacktoberfest, so I'm open to any comments or feedback regarding my contribution 😉

Happy Hacktoberfest!