### PR TITLE
Fix React warning for sourcePosition prop

### DIFF
--- a/src/renderers.js
+++ b/src/renderers.js
@@ -45,7 +45,11 @@ function TextRenderer(props) {
 function Root(props) {
   const useFragment = !props.className
   const root = useFragment ? React.Fragment || 'div' : 'div'
-  return createElement(root, useFragment ? null : props, props.children)
+  const rootProps = Object.assign(
+    props.className ? {className: props.className} : {},
+    getCoreProps(props)
+  )
+  return createElement(root, useFragment ? null : rootProps, props.children)
 }
 
 function SimpleRenderer(tag, props) {

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -2054,6 +2054,16 @@ Array [
 ]
 `;
 
+exports[`should not pass on non core props to root 1`] = `
+<div
+  className="test"
+>
+  <h1>
+    Hello World
+  </h1>
+</div>
+`;
+
 exports[`should skip html blocks if skipHtml prop is set (with HTML parser plugin) 1`] = `
 Array [
   <p>

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -453,6 +453,12 @@ test('should set source position attributes if sourcePos option is enabled', () 
   expect(component.toJSON()).toMatchSnapshot()
 })
 
+test('should not pass on non core props to root', () => {
+  const input = '# Hello World'
+  const component = renderer.create(<Markdown className="test" source={input} rawSourcePos />)
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
 test('should pass on raw source position to non-tag renderers if rawSourcePos option is enabled', () => {
   const input = '*Foo*\n\n------------\n\n__Bar__'
   const emphasis = props => {


### PR DESCRIPTION
Hello,

Thanks so much for maintaining this awesome library! 

I started using the `rawSourcePos` prop and noticed a React warning about a DOM property being set for `sourcePosition`. I traced the error to the `root` renderer and found it wasn't using the `getCoreProps` cleaning method. I updated the renderer to use it and still allow for `className` to be set. Also added a test to ensure the root doesn't render `sourcePosition` props (the test failed before my fix was in place).

Here's the warning I was getting...
<img width="844" alt="Screen Shot 2019-10-24 at 11 38 47 PM" src="https://user-images.githubusercontent.com/9825605/67544103-cff78a80-f6b9-11e9-9845-a8c41ccabe00.png">
