### PR TITLE
Always wrap spans with text even in React 16 to deal with Google Translate

### DIFF
--- a/src/renderers.js
+++ b/src/renderers.js
@@ -4,7 +4,6 @@
 const xtend = require('xtend')
 const React = require('react')
 
-const supportsStringRender = parseInt((React.version || '16').slice(0, 2), 10) >= 16
 const createElement = React.createElement
 
 module.exports = {
@@ -39,7 +38,7 @@ module.exports = {
 }
 
 function TextRenderer(props) {
-  return supportsStringRender ? props.children : createElement('span', null, props.children)
+  return createElement('span', null, props.children)
 }
 
 function Root(props) {


### PR DESCRIPTION
Thanks for React-Markdown! I've noticed users with Google Translate enabled run into a few issues adding/removing dom elements - related to this bug: https://github.com/facebook/react/issues/13278

The errors are like `Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.` and `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`

It appears to be related to the `TextRenderer` element simply returning string literals. While this does work fine in React 16 (seems to be a performance improvement attempt?), it breaks when users have Google Translate enabled. The TLDR is that the string literal is wrapped in a `font` element, silently on the DOM,  which causes React to lose its reference. The "fix" is to always wrap string literals in known-to-react dom elements - thus, always wrapping text with `spans` resolves the problem and fixes React-Markdown for users with Google Translate enabled.

Hopefully this helps! If there is some context around the `supportsStringRender` that I might be missing, please let me know and I can fix the PR!

Thanks!