### PR TITLE
allow nesting tags and close correct tags when multiple tags exist

### DIFF
--- a/src/plugins/html-parser.js
+++ b/src/plugins/html-parser.js
@@ -28,6 +28,7 @@ const defaultConfig = {
 }
 
 function parseHtml(config, tree, props) {
+  const openersByParent = new Map()
   let open
   let currentParent
   visit(
@@ -49,7 +50,12 @@ function parseHtml(config, tree, props) {
       }
 
       if (currentParent !== parent) {
-        open = []
+        if (openersByParent.has(parent)) {
+          open = openersByParent.get(parent)
+        } else {
+          open = []
+          openersByParent.set(parent, open)
+        }
         currentParent = parent
       }
 
@@ -68,7 +74,7 @@ function parseHtml(config, tree, props) {
         return true
       }
 
-      const matching = findAndPull(open, current.tag)
+      const matching = current.opening && findAndPull(open, current.tag)
 
       if (matching) {
         parent.children.splice(index, 0, parsedHtml(current, matching, parent))

--- a/src/plugins/naive-html.js
+++ b/src/plugins/naive-html.js
@@ -10,6 +10,7 @@ const selfClosingRe = /^<(area|base|br|col|embed|hr|img|input|keygen|link|meta|p
 const simpleTagRe = /^<(\/?)([a-z]+)\s*>$/
 
 module.exports = function(tree) {
+  const openersByParent = new Map()
   let open
   let currentParent
   visit(
@@ -17,7 +18,12 @@ module.exports = function(tree) {
     'html',
     (node, index, parent) => {
       if (currentParent !== parent) {
-        open = []
+        if (openersByParent.has(parent)) {
+          open = openersByParent.get(parent)
+        } else {
+          open = []
+          openersByParent.set(parent, open)
+        }
         currentParent = parent
       }
 
@@ -36,7 +42,7 @@ module.exports = function(tree) {
         return true
       }
 
-      const matching = findAndPull(open, current.tag)
+      const matching = current.opening && findAndPull(open, current.tag)
 
       if (matching) {
         parent.children.splice(index, 0, virtual(current, matching, parent))

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -935,51 +935,51 @@ console.log(foo(5));
   <p>
     We used to have a known bug where inline HTML wasn't handled well. You can do basic tags like
 
+    <code>
+      code
+    </code>
+    , as long as it doesn't contain any 
     <span
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<code>",
+          "__html": "<span class=\\"attrs\\">",
         }
       }
     />
-    code
-    <code>
-      , as long as it doesn't contain any 
-      <span
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<span class=\\"attrs\\">",
-          }
+    attributes
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "</span>",
         }
-      />
-      attributes
-      <span
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "</span>",
-          }
-        }
-      />
-      . If you
+      }
+    />
+    . If you
 have weird ordering on your tags, it won't work either. It does support 
-      <strong>
-        nested
+    <strong>
+      nested
 
-        <em>
-          tags
-        </em>
-        , however
-      </strong>
-      . And with the 
-      <span
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<code class=\\"name\\">",
-          }
+      <em>
+        tags
+      </em>
+      , however
+    </strong>
+    . And with the 
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<code class=\\"name\\">",
         }
-      />
-      html-parser
-    </code>
+      }
+    />
+    html-parser
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "</code>",
+        }
+      }
+    />
      plugin, it can now properly handle HTML! Which is pretty sweet.
   </p>,
   <span
@@ -1960,6 +1960,36 @@ exports[`should render empty link references 1`] = `"<p>Stuff were changed in <a
 exports[`should render image references 1`] = `"<p>Checkout out this ninja: <img src=\\"/assets/ninja.png\\" alt=\\"The Waffle Ninja\\"/>. Pretty neat, eh?</p>"`;
 
 exports[`should render link references 1`] = `"<p>Stuff were changed in <a href=\\"https://github.com/rexxars/react-markdown/compare/v1.1.3...v1.1.4\\">1.1.4</a>. Check out the changelog for reference.</p>"`;
+
+exports[`should render nested HTML tags 1`] = `
+<p>
+  <span>
+    <span>
+      Text
+    </span>
+  </span>
+</p>
+`;
+
+exports[`should render nested tags and blocks of markdown (when using htmlParser) 1`] = `
+<details>
+  <p>
+    <abbr>
+      import stage
+    </abbr>
+  </p>
+</details>
+`;
+
+exports[`should render nested tags and blocks of markdown 1`] = `
+<details>
+  <p>
+    <abbr>
+      import stage
+    </abbr>
+  </p>
+</details>
+`;
 
 exports[`should render partial tables 1`] = `"<p>User is writing a table by hand</p><table><thead><tr><th>Test</th><th>Test</th></tr></thead></table>"`;
 

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -816,3 +816,41 @@ test('should render table of contents plugin', () => {
   const component = renderer.create(<Markdown source={input} plugins={[toc]} />)
   expect(component.toJSON()).toMatchSnapshot()
 })
+
+test('should render nested tags and blocks of markdown', () => {
+  const markdown = [
+    '<details>',
+    '',  // creates a <p>
+    '<abbr>import stage</abbr>',
+    '</details>'
+  ].join('\n')
+
+  const component = renderer.create(<Markdown source={markdown} escapeHtml={false} />)
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
+test('should render nested tags and blocks of markdown (when using htmlParser)', () => {
+  const markdown = [
+    '<details>',
+    '',  // creates a <p>
+    '<abbr>import stage</abbr>',
+    '</details>'
+  ].join('\n')
+
+  const component = renderer.create(<Markdown source={markdown} escapeHtml={false} plugins={[htmlParser]} />)
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
+test('should render nested HTML tags', () => {
+  const input = '<span><span>Text</span></span>'
+
+  const component = renderer.create(
+    <Markdown
+      source={input}
+      escapeHtml={false}
+      plugins={[htmlParser]}
+    />
+  )
+
+  expect(component.toJSON()).toMatchSnapshot()
+});


### PR DESCRIPTION
This allows for more liberal nesting of tags and markdown, such as:

* `<span><span>text</span></span>` (which crashed)
* `<div>[some markdown paragraphs with a HTML <span> in them</div>` (which didn't function properly)

I've noticed this project is supposed to be completely ES5, but I've used a Map to keep a record of closing tags at each level. This can be fixed in other ways, like using a Map ponyfill.

Fixes #302