### PR TITLE
Set rel attribute when linkTarget is specified

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -115,7 +115,8 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
             : opts.linkTarget,
         href: opts.transformLinkUri
           ? opts.transformLinkUri(node.url, node.children, node.title)
-          : node.url
+          : node.url,
+        rel: opts.linkTarget ? " rel="noopener noreferrer" : undefined
       })
       break
     case 'image':


### PR DESCRIPTION
This closes a potential security vulnerability. See the below for references.

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md
https://mathiasbynens.github.io/rel-noopener/

Note that this isn't checking whether linkTarget returns "_blank" in the case that it's a function. Might be worthwhile to check though.