### PR TITLE
Fix `renderers` prop in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -88,7 +88,7 @@ declare namespace ReactMarkdown {
     readonly transformLinkUri?: ((uri: string, children?: ReactNode, title?: string) => string) | null
     readonly transformImageUri?: ((uri: string, children?: ReactNode, title?: string, alt?: string) => string) | null
     readonly unwrapDisallowed?: boolean
-    readonly renderers?: {[nodeType: string]: ReactType}
+    readonly renderers?: Renderers
     readonly astPlugins?: MdastPlugin[]
     readonly plugins?: any[] | (() => void)
     readonly parserOptions?: Partial<RemarkParseOptions>


### PR DESCRIPTION
Updated it to user the `Renderers` interface, which allows specifying a renderer as a string, which is useful for conditionally overriding a renderer. For example:

```tsx
const renderers: Renderers = { 
  image: shouldRedactImages // boolean
      ? () => {
          return (<p className='text-secondary font-weight-bold'>[Image Redacted]</p>);
        }   
      : ReactMarkdown.renderers.image //Currently fails to typecheck because the default is a string.
};
```