### PR TITLE
Remove redundant phrase in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,7 +138,7 @@ render(<ReactMarkdown plugins={[gfm]} children={markdown} />, document.body)
 ### Use a plugin
 
 This example shows how to use a plugin.
-In this case, [`remark-gfm`][gfm], which adds support for which adds support for
+In this case, [`remark-gfm`][gfm], which adds support for
 strikethrough, tables, tasklists and URLs directly:
 
 ```jsx


### PR DESCRIPTION
Remove the phrase "which adds support for" in the readme which was repeated twice

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
