### PR TITLE
Add a small note that no css rules are included by default

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -413,6 +413,9 @@ Overwriting `transformLinkUri` or `transformImageUri` to something insecure or
 turning `allowDangerousHtml` on, will open you up to XSS vectors.
 Furthermore, the `plugins` you use and `renderers` you write may be insecure.
 
+## Default Styling
+By default, react-markdown does not include any CSS. You can roll your own css solution or use something pre-built like https://github.com/remarkjs/react-markdown/issues/100#issuecomment-504505123
+
 ## Related
 
 *   [`MDX`](https://github.com/mdx-js/mdx)

--- a/readme.md
+++ b/readme.md
@@ -414,7 +414,8 @@ turning `allowDangerousHtml` on, will open you up to XSS vectors.
 Furthermore, the `plugins` you use and `renderers` you write may be insecure.
 
 ## Default Styling
-By default, react-markdown does not include any CSS. You can roll your own css solution or use something pre-built like https://github.com/remarkjs/react-markdown/issues/100#issuecomment-504505123
+
+By default, react-markdown does not include any CSS.  You can roll your own css solution or use something pre-built like https://github.com/remarkjs/react-markdown/issues/100#issuecomment-504505123
 
 ## Related
 


### PR DESCRIPTION
@wooorm  @rexxars 

I was personally surprised when my markdown didn't look like the markdown in demo page (https://remarkjs.github.io/react-markdown/) and I had to dig through the issues to find out how to get my markdown to look nice. I think that is probably the case for many other people judging by how popular @stahlmanDesign's comment was (https://github.com/remarkjs/react-markdown/issues/100#issuecomment-504505123). 

Adding a small note to the readme would go a long way to making this less of an issue. 

Thanks!

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
