### PR TITLE
Fix exception on missing element from `html-to-react`

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -211,6 +211,11 @@ function assignDefined(target, attrs) {
 
 function mergeNodeChildren(node, parsedChildren) {
   const el = node.element
+  if (el === undefined) {
+    /* istanbul ignore next - `div` fallback for old React. */
+    const Fragment = React.Fragment || 'div'
+    return React.createElement(Fragment, null, null)
+  }
   if (Array.isArray(el)) {
     /* istanbul ignore next - `div` fallback for old React. */
     const Fragment = React.Fragment || 'div'

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -176,7 +176,7 @@ function getNodeProps(node, key, opts, renderer, parent, index) {
       props.allowDangerousHtml = opts.allowDangerousHtml
       props.escapeHtml = opts.escapeHtml
       props.skipHtml = opts.skipHtml
-      props.element = mergeNodeChildren(node, parsedChildren)
+      props.element = node.element ? mergeNodeChildren(node, parsedChildren) : null
       break
     }
     default:
@@ -211,11 +211,6 @@ function assignDefined(target, attrs) {
 
 function mergeNodeChildren(node, parsedChildren) {
   const el = node.element
-  if (el === undefined) {
-    /* istanbul ignore next - `div` fallback for old React. */
-    const Fragment = React.Fragment || 'div'
-    return React.createElement(Fragment, null, null)
-  }
   if (Array.isArray(el)) {
     /* istanbul ignore next - `div` fallback for old React. */
     const Fragment = React.Fragment || 'div'

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -894,9 +894,10 @@ test('should support formatting at the start of a GFM tasklist (GH-494)', () => 
   expect(actual).toEqual(expected)
 })
 
-test('should not crush on ending tag at start', () => {
+test('should not crash on weird `html-to-react` results', () => {
   const input = '<ruby><ruby></ruby></ruby>'
-  expect(() =>
-    renderHTML(<Markdown source={input} escapeHtml={false} astPlugins={[htmlParser()]} />)
-  ).not.toThrow()
+  const actual = renderHTML(<MarkdownWithHtml allowDangerousHtml children={input} />)
+  // Note: this is not conforming to how browsers deal with it.
+  const expected = '<p><ruby></ruby><ruby></ruby></p>'
+  expect(actual).toEqual(expected)
 })

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -893,3 +893,10 @@ test('should support formatting at the start of a GFM tasklist (GH-494)', () => 
   const expected = '<ul><li><input type="checkbox" readonly=""/><em>a</em></li></ul>'
   expect(actual).toEqual(expected)
 })
+
+test('should not crush on ending tag at start', () => {
+  const input = '<ruby><ruby></ruby></ruby>'
+  expect(() =>
+    renderHTML(<Markdown source={input} escapeHtml={false} astPlugins={[htmlParser()]} />)
+  ).not.toThrow()
+})


### PR DESCRIPTION
I have noticed that if your html is incorrect - starts with close tag, the solution crushes,
I thought it might be better to just skip the problematic tag with empty div or fragment