### PR TITLE
allow passing in a parsed tree as a prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,7 @@ declare namespace ReactMarkdown {
       | null
     readonly renderers?: {[nodeType: string]: ElementType}
     readonly astPlugins?: PluggableList
+    readonly tree?: unist.Node
     readonly plugins?: PluggableList
     readonly unwrapDisallowed?: boolean
   }

--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -26,12 +26,15 @@ const ReactMarkdown = function ReactMarkdown(props) {
 
   const renderers = xtend(defaultRenderers, props.renderers)
 
-  const processor = unified()
-    .use(parse)
-    .use(props.plugins || [])
+  let tree = props.tree
+  if (!tree) {
+    const processor = unified()
+      .use(parse)
+      .use(props.plugins || [])
 
-  // eslint-disable-next-line no-sync
-  let tree = processor.runSync(processor.parse(src))
+    // eslint-disable-next-line no-sync
+    tree = processor.runSync(processor.parse(src))
+  }
 
   const renderProps = xtend(props, {renderers: renderers, definitions: getDefinitions(tree)})
 
@@ -103,6 +106,7 @@ ReactMarkdown.propTypes = {
   astPlugins: PropTypes.arrayOf(PropTypes.func),
   unwrapDisallowed: PropTypes.bool,
   renderers: PropTypes.object,
+  tree: PropTypes.object,
   plugins: PropTypes.array
 }
 


### PR DESCRIPTION
If the user has already parsed the tree for other purposes, it can be useful to just pass in the parsed tree. This way the `renderers` logic etc can still be used while moving the parsing out