### PR TITLE
test: drop enzyme as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,6 @@
     "@types/react-dom": "^16.0.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "dtslint": "^4.0.0",
-    "enzyme": "^3.10.0",
-    "enzyme-adapter-react-16": "^1.0.0",
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-config-sanity": "^4.0.0",

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -1389,6 +1389,16 @@ exports[`should be able to render inline html with self-closing tags properly wi
 </p>
 `;
 
+exports[`should be able to render inline html with self-closing tags with attributes properly with HTML parser plugin (#2) 1`] = `
+<p>
+  I am having 
+  <wbr
+    className="foo"
+  />
+   so much fun
+</p>
+`;
+
 exports[`should be able to render inline html with self-closing tags with attributes properly with HTML parser plugin 1`] = `
 <p>
   I am having 

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -1,7 +1,5 @@
 /* eslint-env jest */
 /* eslint-disable react/prop-types */
-const Enzyme = require('enzyme')
-const Adapter = require('enzyme-adapter-react-16')
 const fs = require('fs')
 const path = require('path')
 const React = require('react')
@@ -15,8 +13,6 @@ const htmlParser = require('../src/plugins/html-parser')
 const Markdown = require('../src/react-markdown')
 const MarkdownWithHtml = require('../src/with-html')
 const toc = require('remark-toc')
-
-Enzyme.configure({adapter: new Adapter()})
 
 const renderHTML = (input) => ReactDom.renderToStaticMarkup(input).replace(/^<div>|<\/div>$/g, '')
 
@@ -314,7 +310,10 @@ test('should be able to render inline html with self-closing tags with attribute
 
 test('should be able to render inline html with self-closing tags with attributes properly with HTML parser plugin (#2)', () => {
   const input = 'I am having <wbr class="foo"/> so much fun'
-  Enzyme.mount(<Markdown children={input} allowDangerousHtml astPlugins={[htmlParser()]} />)
+  const component = renderer.create(
+    <Markdown children={input} allowDangerousHtml astPlugins={[htmlParser()]} />
+  )
+  expect(component.toJSON()).toMatchSnapshot()
 })
 
 test('should be able to render multiple inline html elements with self-closing tags with attributes properly with HTML parser plugin', () => {


### PR DESCRIPTION
it was only used for one test, and does not appear to be needed.
This unblocks https://github.com/remarkjs/react-markdown/pull/498#issuecomment-716186190