### PR TITLE
docs: remove github flavored table from example/demo of commonmark

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,11 +40,18 @@ Pretty neat, eh?
 
 ## Tables?
 
+Use [\`remark-gfm\`](https://github.com/remarkjs/react-markdown#use) to support tables, strikethrough, tasklists, and literal URLs.
+Theses features **do not work by default**.
+
 | Feature   | Support |
 | :-------: | ------- |
-| tables    | ✔ |
-| alignment | ✔ |
-| wewt      | ✔ |
+| tables    | \`remark-gfm\` |
+
+~~strikethrough~~
+
+- [ ] task list
+
+https://example.com
 
 ## More info?
 


### PR DESCRIPTION
including an example of GitHub flavored markdown in the CommonMark demo leads to confusion (see https://github.com/remarkjs/react-markdown/issues/529, https://github.com/remarkjs/react-markdown/issues/524, https://github.com/remarkjs/react-markdown/issues/525, https://github.com/remarkjs/react-markdown/issues/526).
This removes GFM from the commonmark demo to reduce confusion.

An alternative could be to add a toggle to enable/disable `remark-gfm` on the demo site.