### PR TITLE
Fix `uri-transformer.js` link on README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -490,7 +490,7 @@ abide by its terms.
 
 [remark-plugins]: https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins
 
-[uri]: https://github.com/remarkjs/react-markdown/blob/v5/src/uri-transformer.js
+[uri]: https://github.com/remarkjs/react-markdown/blob/main/src/uri-transformer.js
 
 [security]: #security
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->

close #542 
Fix `uri-transformer.js` link on README.
