### PR TITLE
Fix/Work around for invalid html with empty props  `Might close #345`

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -208,6 +208,9 @@ function assignDefined(target, attrs) {
 
 function mergeNodeChildren(node, parsedChildren) {
   const el = node.element
+  
+  if(!el || !el.props) return '';
+  
   if (Array.isArray(el)) {
     return React.createElement(React.Fragment, null, el)
   }


### PR DESCRIPTION
Fix breaking changed with empty node props from invalid html
`Might close #345`
```
      WebpackError: TypeError: Cannot read property 'children' of undefined
```

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
