### PR TITLE
Remove compiled library

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 coverage/
-lib/
 react-markdown.min.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 coverage/
-lib/
 node_modules/
 *.d.ts
 *.log

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,4 @@
 coverage/
-lib/
 *.html
 *.md
 react-markdown.min.js

--- a/package.json
+++ b/package.json
@@ -67,11 +67,11 @@
     "Dennis S <denis.s@svsg.co>",
     "Evan Hensleigh <futuraprime@gmail.com>"
   ],
-  "types": "lib/react-markdown.d.ts",
-  "main": "lib/react-markdown.js",
+  "types": "src/react-markdown.d.ts",
+  "main": "src/react-markdown.js",
   "unpkg": "react-markdown.min.js",
   "files": [
-    "lib/",
+    "src/",
     "react-markdown.min.js"
   ],
   "dependencies": {
@@ -93,7 +93,6 @@
     "react": ">=16"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
@@ -138,8 +137,7 @@
   },
   "scripts": {
     "prepack": "npm run build && npm run format",
-    "build:lib": "rimraf lib/ && babel src/ --quiet --copy-files -d lib/",
-    "build:ts": "rimraf \"{src/**,lib/**,}.d.ts\" && tsc && type-coverage",
+    "build:ts": "rimraf \"{src/**,test/**,}.d.ts\" && tsc && type-coverage",
     "build:umd": "rollup --silent -c",
     "build:umdcheck": "printf 'ES5? ' && uglifyjs react-markdown.min.js > /dev/null && echo 'Yes'",
     "build": "run-s build:*",


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->

I don’t think we need a prebuilt `lib/`; the source code is usable as-is