### PR TITLE
Remove trailing \n in pre.code

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -171,7 +171,11 @@ function childrenToReact(context, node) {
     if (child.type === 'element') {
       children.push(toReact(context, child, childIndex, node))
     } else if (child.type === 'text') {
-      children.push(child.value)
+      if (node.tagName === 'code' && !node.properties.inline) {
+        children.push(child.value.replace(/\n$/, ''))
+      } else {
+        children.push(child.value)
+      }
     }
     // @ts-ignore `raw` nodes are non-standard
     else if (child.type === 'raw' && !context.options.skipHtml) {

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -360,7 +360,6 @@ Array [
 line 1 of code
 line 2 of code
 line 3 of code
-
     </code>
   </pre>,
   "
@@ -373,7 +372,6 @@ line 3 of code
   <pre>
     <code>
       Sample text here...
-
     </code>
   </pre>,
   "
@@ -392,7 +390,6 @@ line 3 of code
 };
 
 console.log(foo(5));
-
     </code>
   </pre>,
   "
@@ -1080,7 +1077,6 @@ Array [
 line 1 of code
 line 2 of code
 line 3 of code
-
     </code>
   </pre>,
   "
@@ -1093,7 +1089,6 @@ line 3 of code
   <pre>
     <code>
       Sample text here...
-
     </code>
   </pre>,
   "
@@ -1112,7 +1107,6 @@ line 3 of code
 };
 
 console.log(foo(5));
-
     </code>
   </pre>,
   "
@@ -1795,8 +1789,7 @@ exports[`should handle bold/strong text 1`] = `
 exports[`should handle code blocks by indentation 1`] = `
 "<pre><code>&lt;footer class=&quot;footer&quot;&gt;
     &amp;copy; 2014 Foo Bar
-&lt;/footer&gt;
-</code></pre>"
+&lt;/footer&gt;</code></pre>"
 `;
 
 exports[`should handle code tags with language specification 1`] = `
@@ -1806,7 +1799,6 @@ exports[`should handle code tags with language specification 1`] = `
   >
     var foo = require('bar');
 foo();
-
   </code>
 </pre>
 `;
@@ -1816,7 +1808,6 @@ exports[`should handle code tags without any language specification 1`] = `
   <code>
     var foo = require('bar');
 foo();
-
   </code>
 </pre>
 `;
@@ -2190,7 +2181,6 @@ exports[`should only use first language definition on code blocks 1`] = `
   >
     var foo = require('bar');
 foo();
-
   </code>
 </pre>
 `;
@@ -2597,7 +2587,6 @@ names
 !@#$%^&*()_"
   >
       woop
-
   </code>
 </pre>
 `;


### PR DESCRIPTION
every `pre.code` tag have one redundant blank line

**Expected**

```
line 1 of code
line 2 of code
line 3 of code
```

**Actual**

```
line 1 of code
line 2 of code
line 3 of code

```

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
