### PR TITLE
Fix whitespace in table elements

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -172,11 +172,13 @@ function childrenToReact(context, node) {
       children.push(toReact(context, child, childIndex, node))
     } else if (child.type === 'text') {
       // Text elements are not permitted as children of table:
-      if (node.tagName !== 'table' &&
-          node.tagName !== 'thead' &&
-          node.tagName !== 'tbody' &&
-          node.tagName !== 'tfoot' &&
-          node.tagName !== 'tr') {
+      if (
+        node.tagName !== 'table' &&
+        node.tagName !== 'thead' &&
+        node.tagName !== 'tbody' &&
+        node.tagName !== 'tfoot' &&
+        node.tagName !== 'tr'
+      ) {
         children.push(child.value)
       }
     }

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -171,7 +171,14 @@ function childrenToReact(context, node) {
     if (child.type === 'element') {
       children.push(toReact(context, child, childIndex, node))
     } else if (child.type === 'text') {
-      children.push(child.value)
+      // Text elements are not permitted as children of table:
+      if (node.tagName !== 'table' &&
+          node.tagName !== 'thead' &&
+          node.tagName !== 'tbody' &&
+          node.tagName !== 'tfoot' &&
+          node.tagName !== 'tr') {
+        children.push(child.value)
+      }
     }
     // @ts-ignore `raw` nodes are non-standard
     else if (child.type === 'raw' && !context.options.skipHtml) {

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -154,6 +154,10 @@ exports.hastChildrenToReact = childrenToReact
 
 const own = {}.hasOwnProperty
 
+// The table-related elements that must not contain whitespace text according
+// to React.
+const tableElements = new Set(['table', 'thead', 'tbody', 'tfoot', 'tr'])
+
 /**
  * @param {Context} context
  * @param {Element|Root} node
@@ -171,14 +175,12 @@ function childrenToReact(context, node) {
     if (child.type === 'element') {
       children.push(toReact(context, child, childIndex, node))
     } else if (child.type === 'text') {
-      // Text elements are not permitted as children of table:
-      if (
-        node.tagName !== 'table' &&
-        node.tagName !== 'thead' &&
-        node.tagName !== 'tbody' &&
-        node.tagName !== 'tfoot' &&
-        node.tagName !== 'tr'
-      ) {
+      /** @type {ReactMarkdownNames} */
+      // @ts-ignore assume a known HTML/SVG element.
+      const name = node.tagName
+      // React does not permit whitespace text elements as children of table:
+      // cf. https://github.com/remarkjs/react-markdown/issues/576
+      if (!tableElements.has(name) || child.value !== '\n') {
         children.push(child.value)
       }
     }

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -2335,14 +2335,7 @@ exports[`should render link references 1`] = `"<p>Stuff were changed in <a href=
 
 exports[`should render partial tables 1`] = `
 "<p>User is writing a table by hand</p>
-<table>
-<thead>
-<tr>
-<th>Test</th>
-<th>Test</th>
-</tr>
-</thead>
-</table>"
+<table><thead><tr><th>Test</th><th>Test</th></tr></thead></table>"
 `;
 
 exports[`should render table of contents plugin 1`] = `
@@ -2446,36 +2439,7 @@ Array [
 
 exports[`should render tables 1`] = `
 "<p>Languages are fun, right?</p>
-<table>
-<thead>
-<tr>
-<th style=\\"text-align:left\\">ID</th>
-<th style=\\"text-align:center\\">English</th>
-<th style=\\"text-align:right\\">Norwegian</th>
-<th>Italian</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td style=\\"text-align:left\\">1</td>
-<td style=\\"text-align:center\\">one</td>
-<td style=\\"text-align:right\\">en</td>
-<td>uno</td>
-</tr>
-<tr>
-<td style=\\"text-align:left\\">2</td>
-<td style=\\"text-align:center\\">two</td>
-<td style=\\"text-align:right\\">to</td>
-<td>due</td>
-</tr>
-<tr>
-<td style=\\"text-align:left\\">3</td>
-<td style=\\"text-align:center\\">three</td>
-<td style=\\"text-align:right\\">tre</td>
-<td>tre</td>
-</tr>
-</tbody>
-</table>"
+<table><thead><tr><th style=\\"text-align:left\\">ID</th><th style=\\"text-align:center\\">English</th><th style=\\"text-align:right\\">Norwegian</th><th>Italian</th></tr></thead><tbody><tr><td style=\\"text-align:left\\">1</td><td style=\\"text-align:center\\">one</td><td style=\\"text-align:right\\">en</td><td>uno</td></tr><tr><td style=\\"text-align:left\\">2</td><td style=\\"text-align:center\\">two</td><td style=\\"text-align:right\\">to</td><td>due</td></tr><tr><td style=\\"text-align:left\\">3</td><td style=\\"text-align:center\\">three</td><td style=\\"text-align:right\\">tre</td><td>tre</td></tr></tbody></table>"
 `;
 
 exports[`should set source position attributes if sourcePos option is enabled 1`] = `

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -406,7 +406,7 @@ test('should pass `isHeader: boolean` to `tr`s', () => {
     />
   )
   const expected =
-    '<table>\n<thead>\n<tr>\n<th>a</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>b</td>\n</tr>\n<tr>\n<td>c</td>\n</tr>\n</tbody>\n</table>'
+    '<table><thead><tr><th>a</th></tr></thead><tbody><tr><td>b</td></tr><tr><td>c</td></tr></tbody></table>'
   expect(actual).toEqual(expected)
 })
 
@@ -429,7 +429,7 @@ test('should pass `isHeader: true` to `th`s, `isHeader: false` to `td`s', () => 
     />
   )
   const expected =
-    '<table>\n<thead>\n<tr>\n<th>a</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>b</td>\n</tr>\n<tr>\n<td>c</td>\n</tr>\n</tbody>\n</table>'
+    '<table><thead><tr><th>a</th></tr></thead><tbody><tr><td>b</td></tr><tr><td>c</td></tr></tbody></table>'
   expect(actual).toEqual(expected)
 })
 
@@ -1169,7 +1169,7 @@ test('should support table cells w/ style', () => {
     <Markdown children={input} remarkPlugins={[gfm]} rehypePlugins={[plugin]} />
   )
   const expected =
-    '<table>\n<thead>\n<tr>\n<th style="color:red;text-align:left">a</th>\n</tr>\n</thead>\n</table>'
+    '<table><thead><tr><th style="color:red;text-align:left">a</th></tr></thead></table>'
 
   expect(actual).toEqual(expected)
 })


### PR DESCRIPTION
React Markdown 6.0.0 with Remark Parse 9.0.0, Remark Rehype 8.1.0, Remark
GFM 1.0.0 and React 17.0.2 would cause warnings in the developer console:

> Warning: validateDOMNesting(...): Whitespace text nodes cannot appear as a
> child of `<table>`. Make sure you don't have any extra whitespace between
> tags on each line of your source code.

In fact `<table>`, `<tbody>`, `<thead>`, `<tr>` all do not permit any text
elements to appear directly inside them.  See e.g.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table

Hence we strip any text element from the children of these elements
unconditionally.

Closes: https://github.com/remarkjs/react-markdown/issues/576
