### PR TITLE
Add string type for `className`s

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -77,7 +77,8 @@ exports.hastChildrenToReact = childrenToReact
  *
  * @typedef {keyof IntrinsicElements} ReactMarkdownNames
  *
- * @typedef {Object.<string, unknown>} ReactBaseProps
+ * @typedef {Object} ReactBaseProps
+ * @property {string?} className
  *
  * To do: is `data-sourcepos` typeable?
  *
@@ -94,7 +95,7 @@ exports.hastChildrenToReact = childrenToReact
  * @returns {ReactNode}
  *
  * @callback CodeComponent
- * @param {ReactBaseProps & ReactMarkdownProps & {inline?: boolean, className?: string}} props
+ * @param {ReactBaseProps & ReactMarkdownProps & {inline?: boolean}} props
  * @returns {ReactNode}
  *
  * @callback HeadingComponent

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -94,7 +94,7 @@ exports.hastChildrenToReact = childrenToReact
  * @returns {ReactNode}
  *
  * @callback CodeComponent
- * @param {ReactBaseProps & ReactMarkdownProps & {inline?: boolean}} props
+ * @param {ReactBaseProps & ReactMarkdownProps & {inline?: boolean, className?: string}} props
  * @returns {ReactNode}
  *
  * @callback HeadingComponent

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -77,8 +77,7 @@ exports.hastChildrenToReact = childrenToReact
  *
  * @typedef {keyof IntrinsicElements} ReactMarkdownNames
  *
- * @typedef {Object} ReactBaseProps
- * @property {string?} className
+ * @typedef {{ [key: string]: unknown, className?: string }} ReactBaseProps
  *
  * To do: is `data-sourcepos` typeable?
  *


### PR DESCRIPTION
Hello.
Thank you for the very nice package.
Thanks to react-markdown, my development is going very smoothly.

I added the `className` to the `CodeComponent` type because it is not defined in the script, while it is in `README.md`.
I have confirmed that it works on my environment, so I would be happy if you could adopt it.

Thank you for your consideration.

<img width="778" alt="スクリーンショット 2021-04-28 13 38 00" src="https://user-images.githubusercontent.com/28823042/116348380-fb1be680-a828-11eb-8dbe-2f0f08eb0925.png">
