### PR TITLE
fix react-syntax-highlighter example in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,7 +252,12 @@ import {render} from 'react-dom'
 const components = {
   code({node, inline, className, children, ...props}) {
     const match = /language-(\w+)/.exec(className || '')
-    return !inline && match ? (
+    if(inline) {
+      return (
+        <SyntaxHighlighter style={dark} useInlineStyles={true} PreTag="span" children={String(children).replace(/\n$/, '')} {...props} />
+      )
+    }
+    return match ? (
       <SyntaxHighlighter style={dark} language={match[1]} PreTag="div" children={String(children).replace(/\n$/, '')} {...props} />
     ) : (
       <code className={className} {...props} />


### PR DESCRIPTION
In a given `react-syntax-highlighter` example, it skips inline code rendering, so I fixed it.