### PR TITLE
Include sourcePosition with rehype-raw

### DIFF
--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -98,9 +98,10 @@ function ReactMarkdown(options) {
     .use(options.rehypePlugins || [])
     .use(filter, options)
 
+  const contents = options.children || ''
   /** @type {Root} */
   // @ts-ignore we’ll throw if it isn’t a root next.
-  const hastNode = processor.runSync(processor.parse(options.children || ''))
+  const hastNode = processor.runSync(processor.parse(contents), {contents})
 
   if (hastNode.type !== 'root') {
     throw new TypeError('Expected a `root` node')

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -2327,6 +2327,43 @@ Array [
 ]
 `;
 
+exports[`should pass on raw source position to non-tag components if rawSourcePos option is enabled and rehype-raw is used 1`] = `
+Object {
+  "end": Object {
+    "column": 6,
+    "line": 1,
+    "offset": 5,
+  },
+  "start": Object {
+    "column": 1,
+    "line": 1,
+    "offset": 0,
+  },
+}
+`;
+
+exports[`should pass on raw source position to non-tag components if rawSourcePos option is enabled and rehype-raw is used 2`] = `
+Array [
+  <p>
+    <em
+      className="custom"
+    >
+      Foo
+    </em>
+  </p>,
+  "
+",
+  <hr />,
+  "
+",
+  <p>
+    <strong>
+      Bar
+    </strong>
+  </p>,
+]
+`;
+
 exports[`should render empty link references 1`] = `"<p>Stuff were changed in [][]. Check out the changelog for reference.</p>"`;
 
 exports[`should render image references 1`] = `"<p>Checkout out this ninja: <img src=\\"/assets/ninja.png\\" alt=\\"The Waffle Ninja\\"/>. Pretty neat, eh?</p>"`;

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -11,6 +11,7 @@ const TeX = require('@matejmazur/react-katex')
 const {render} = require('@testing-library/react')
 const Markdown = require('../src/react-markdown')
 const toc = require('remark-toc')
+const rehypeRaw = require('rehype-raw')
 
 /**
  * @typedef {import('unist').Position} Position
@@ -543,6 +544,30 @@ test('should pass on raw source position to non-tag components if rawSourcePos o
 
   const component = renderer.create(
     <Markdown children={input} rawSourcePos components={{em}} />
+  )
+
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
+test('should pass on raw source position to non-tag components if rawSourcePos option is enabled and rehype-raw is used', () => {
+  const input = '*Foo*\n\n------------\n\n__Bar__'
+  /**
+   * @param {Object} props
+   * @param {Element} props.node
+   * @param {Position} [props.sourcePosition]
+   */
+  const em = ({node, sourcePosition, ...props}) => {
+    expect(sourcePosition).toMatchSnapshot()
+    return <em className="custom" {...props} />
+  }
+
+  const component = renderer.create(
+    <Markdown
+      children={input}
+      rawSourcePos
+      components={{em}}
+      rehypePlugins={[rehypeRaw]}
+    />
   )
 
   expect(component.toJSON()).toMatchSnapshot()


### PR DESCRIPTION
This PR fixes a bug where `sourcePosition` would not be set when `rehype-raw` is used as a rehype plugin.