### PR TITLE
add `ImageComponent` into types

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -77,7 +77,8 @@ exports.hastChildrenToReact = childrenToReact
  *
  * @typedef {keyof IntrinsicElements} ReactMarkdownNames
  *
- * @typedef {Object.<string, unknown>} ReactBaseProps
+ * @typedef {Object} ReactBaseProps
+ * @property {string?} className
  *
  * To do: is `data-sourcepos` typeable?
  *
@@ -94,7 +95,7 @@ exports.hastChildrenToReact = childrenToReact
  * @returns {ReactNode}
  *
  * @callback CodeComponent
- * @param {ReactBaseProps & ReactMarkdownProps & {inline?: boolean, className?: string}} props
+ * @param {ReactBaseProps & ReactMarkdownProps & {inline?: boolean}} props
  * @returns {ReactNode}
  *
  * @callback HeadingComponent

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -121,6 +121,10 @@ exports.hastChildrenToReact = childrenToReact
  * @param {ReactBaseProps & ReactMarkdownProps & {depth: number, ordered: false}} props
  * @returns {ReactNode}
  *
+ * @callback ImageComponent
+ * @param {ReactBaseProps & ReactMarkdownProps & {src: string, alt: string}} props
+ * @returns {ReactNode}
+ *
  * @typedef {Object} SpecialComponents
  * @property {CodeComponent|ReactMarkdownNames} code
  * @property {HeadingComponent|ReactMarkdownNames} h1
@@ -135,6 +139,7 @@ exports.hastChildrenToReact = childrenToReact
  * @property {TableCellComponent|ReactMarkdownNames} th
  * @property {TableRowComponent|ReactMarkdownNames} tr
  * @property {UnorderedListComponent|ReactMarkdownNames} ul
+ * @property {ImageComponent|ReactMarkdownNames} img
  *
  * @typedef {Record<Exclude<ReactMarkdownNames, keyof SpecialComponents>, NormalComponent|ReactMarkdownNames>} NormalComponents
  * @typedef {Partial<NormalComponents & SpecialComponents>} Components

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -94,7 +94,7 @@ exports.hastChildrenToReact = childrenToReact
  * @returns {ReactNode}
  *
  * @callback CodeComponent
- * @param {ReactBaseProps & ReactMarkdownProps & {inline?: boolean}} props
+ * @param {ReactBaseProps & ReactMarkdownProps & {inline?: boolean, className?: string}} props
  * @returns {ReactNode}
  *
  * @callback HeadingComponent

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -77,8 +77,7 @@ exports.hastChildrenToReact = childrenToReact
  *
  * @typedef {keyof IntrinsicElements} ReactMarkdownNames
  *
- * @typedef {Object} ReactBaseProps
- * @property {string?} className
+ * @typedef {{ [key: string]: unknown, className?: string }} ReactBaseProps
  *
  * To do: is `data-sourcepos` typeable?
  *


### PR DESCRIPTION
Hello.
Thanks again for developing such a great package.

When using `components`, there was no property set for the `img` tag, so I created an `ImageComponent` type and applied it to the `img` tag.
I'm not sure if I should add `width` and `height` as well, so please add those as well if needed.

The test has of course passed, plus it has been verified to work in my environment.

Thank you for your consideration.