### PR TITLE
Fix syntax highlighting example in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -255,7 +255,9 @@ const components = {
     return !inline && match ? (
       <SyntaxHighlighter style={dark} language={match[1]} PreTag="div" children={String(children).replace(/\n$/, '')} {...props} />
     ) : (
-      <code className={className} {...props} />
+      <code className={className} {...props}>
+        {children}
+      </code>
     )
   }
 }


### PR DESCRIPTION
Fixed SyntaxHighlighter example in readme.md not rendering inline code, see See remarkjs#587

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
