### PR TITLE
Fix types

### DIFF
--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -282,7 +282,12 @@ function toReact(context, node, index, parent) {
     )
   }
 
-  if (!basic && name === 'code' && parent.tagName !== 'pre') {
+  if (
+    !basic &&
+    name === 'code' &&
+    parent.type === 'element' &&
+    parent.tagName !== 'pre'
+  ) {
     properties.inline = true
   }
 
@@ -307,7 +312,7 @@ function toReact(context, node, index, parent) {
     )
   }
 
-  if (!basic && name === 'li') {
+  if (!basic && name === 'li' && parent.type === 'element') {
     const input = getInputElement(node)
     properties.checked = input ? Boolean(input.properties.checked) : null
     properties.index = getElementsBeforeCount(parent, node)
@@ -332,7 +337,7 @@ function toReact(context, node, index, parent) {
     }
   }
 
-  if (!basic && name === 'tr') {
+  if (!basic && name === 'tr' && parent.type === 'element') {
     properties.isHeader = Boolean(parent.tagName === 'thead')
   }
 

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -880,6 +880,8 @@ test('should support math', () => {
       Array.isArray(node.properties.className) &&
       node.properties.className.includes('math')
     ) {
+      if (!(node.children[0].type === 'text'))
+        throw new TypeError('math is not text')
       return (
         // @ts-ignore broken types?
         <TeX
@@ -1215,8 +1217,13 @@ test('should support (ignore) comments', () => {
 test('should support table cells w/ style', () => {
   const input = '| a  |\n| :- |'
   const plugin = () => (/** @type {Root} */ tree) => {
-    const th = tree.children[0].children[1].children[1].children[1]
-    th.properties.style = 'color: red'
+    visit(
+      tree,
+      {type: 'element', tagName: 'th'},
+      (/** @type {Element} */ th) => {
+        th.properties.style = 'color: red'
+      }
+    )
   }
 
   const actual = renderHTML(


### PR DESCRIPTION
adds checks to `ast-to-react` to handle edge cases with `Root` node possibly being a parent.
update test cases to narrow typings where needed.