### PR TITLE
Add `transformText` prop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,10 @@ render(<ReactMarkdown remarkPlugins={[gfm]} children={markdown} />, document.bod
 *   `transformImageUri` (`(src, alt, title) => string`, default:
     [`./uri-transformer.js`][uri], optional)\
     Same as `transformLinkUri` but for images
+*   `transformText` (`(text, index, node, parentNode) => string | ReactNode`,
+    default: `undefined`, optional)\
+    Applies any transformations to each fragment of text to return either
+    modified text or a React component used to render the text.
 *   `components` (`Object.<string, Component>`, default: `{}`)\
     Object mapping tag names to React components
 *   `remarkPlugins` (`Array.<Plugin>`, default: `[]`)\

--- a/src/ast-to-react.js
+++ b/src/ast-to-react.js
@@ -69,6 +69,13 @@ exports.hastChildrenToReact = childrenToReact
  * @param {string?} title
  * @returns {string}
  *
+ * @callback TransformText
+ * @param {string} text
+ * @param {number} index
+ * @param {Text} node
+ * @param {Element|Root} parentNode
+ * @returns {string|ReactNode}
+ *
  * @callback TransformLinkTarget
  * @param {string} href
  * @param {Array.<Comment|Element|Text>} children
@@ -148,6 +155,7 @@ exports.hastChildrenToReact = childrenToReact
  * @property {boolean} [includeElementIndex=false]
  * @property {false|TransformLink} [transformLinkUri]
  * @property {TransformImage} [transformImageUri]
+ * @property {TransformText} [transformText]
  * @property {string|TransformLinkTarget} [linkTarget]
  * @property {Components} [components]
  */
@@ -182,7 +190,16 @@ function childrenToReact(context, node) {
         !tableElements.has(node.tagName) ||
         child.value !== '\n'
       ) {
-        children.push(child.value)
+        children.push(
+          context.options.transformText
+            ? context.options.transformText(
+                child.value,
+                childIndex,
+                child,
+                node
+              )
+            : child.value
+        )
       }
     }
     // @ts-ignore `raw` nodes are non-standard

--- a/src/react-markdown.js
+++ b/src/react-markdown.js
@@ -173,6 +173,7 @@ ReactMarkdown.propTypes = {
   transformLinkUri: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
   linkTarget: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   transformImageUri: PropTypes.func,
+  transformText: PropTypes.func,
   components: PropTypes.object
 }
 

--- a/test/__snapshots__/react-markdown.test.js.snap
+++ b/test/__snapshots__/react-markdown.test.js.snap
@@ -2123,6 +2123,23 @@ exports[`should handle ordered lists with a start index 1`] = `
 </ol>
 `;
 
+exports[`should handle text with custom text transformer 1`] = `
+<p>
+  <span
+    style={
+      Object {
+        "color": "red",
+      }
+    }
+  >
+    Congratulations! 
+  </span>
+  <strong>
+    You won!
+  </strong>
+</p>
+`;
+
 exports[`should handle tight, unordered lists 1`] = `
 <ul>
   

--- a/test/react-markdown.test.js
+++ b/test/react-markdown.test.js
@@ -151,6 +151,28 @@ test('should handle links with custom uri transformer', () => {
   expect(component.toJSON()).toMatchSnapshot()
 })
 
+test('should handle text with custom text transformer', () => {
+  const input = 'Congratulations! **You won!**'
+  /**
+   * @param {string} text
+   * @param {number} index
+   * @returns {string|ReactNode}
+   */
+  const transform = (text, index) =>
+    text.startsWith('Congratulations') ? (
+      <span key={index} style={{color: 'red'}}>
+        {text}
+      </span>
+    ) : (
+      text
+    )
+  const component = renderer.create(
+    <Markdown children={input} transformText={transform} />
+  )
+
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
 test('should use target attribute for links if specified', () => {
   const input = 'This is [a link](https://espen.codes/) to Espen.Codes.'
   const component = renderer.create(


### PR DESCRIPTION
Adds a `transformText` prop to allow text fragments to be transformed (e.g., filtered or wrapped with a React component).

This prop can be used to replace the functionality of the `text` renderer that was removed in v6.0.0. 

This specifically addresses the cross-cutting concern of altering the rendering of text within `react-markdown` that was previously supported by this library. While it is possible to override every potential HTML tag under `components` that might render text, doing this is unnecessarily complex and requires additional configuration for each plugin that adds new potential tags (e.g., `gfm`). The `transformText` prop provides a single place for all text transformations & rendering to occur.

It can be used, for example, to wrap all text within `Typography` elements or filter sensitive information. For example, to ensure all text is rendered with the correct typography, the following can be used:

```
<ReactMarkdown 
  transformText={(text, index) => 
    <Typography key={index} variant="body1" component="span" inline>{text}</Typography>
  }
>
  {markdown}
</ReactMarkdown>
```

Closes GH-618 and GH-609, and addresses the issues raised in the discussion at remarkjs/remark#700

