### PR TITLE
docs: add 'remark-gfm@1.0.0'  as v2 is not compatible

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,10 @@ Here is an example using `require`s, passing the markdown as a string, and how
 to use a plugin ([`remark-gfm`][gfm], which adds support for strikethrough,
 tables, tasklists and URLs directly):
 
+```sh
+npm install remark-gfm@1.0.0
+```
+
 ```jsx
 const React = require('react')
 const ReactMarkdown = require('react-markdown')


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [ ] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [ ] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [ ] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [ ] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests

### Description of changes

TODO

<!--do not edit: pr-->
