### PR TITLE
Add improved type for `linkTarget` as string

### DIFF
--- a/lib/ast-to-react.js
+++ b/lib/ast-to-react.js
@@ -32,6 +32,8 @@
  * @param {string?} title
  * @returns {string}
  *
+ * @typedef {import("react").HTMLAttributeAnchorTarget} TransformLinkTargetType
+ *
  * @callback TransformLinkTarget
  * @param {string} href
  * @param {Array.<ElementContent>} children
@@ -86,8 +88,6 @@
  * @property {UnorderedListComponent|ReactMarkdownNames} ul
  *
  * @typedef {Partial<Omit<import("./complex-types").NormalComponents, keyof SpecialComponents> & SpecialComponents>} Components
- *
- * @typedef {"_blank"|"_top"|"_parent"|"_self"|(string & {})} TransformLinkTargetType
  *
  * @typedef Options
  * @property {boolean} [sourcePos=false]


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Added type for `linkTarget`. This will auto complete in most editors, [MDN docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/target#usage_notes)
<!--do not edit: pr-->
