### PR TITLE
Allow SpecialComponents to be any ComponentType

### DIFF
--- a/lib/ast-to-react.js
+++ b/lib/ast-to-react.js
@@ -1,4 +1,9 @@
 /**
+ * @template T
+ * @typedef {import('react').ComponentType<T>} ComponentType<T>
+ */
+
+/**
  * @typedef {import('react').ReactNode} ReactNode
  * @typedef {import('unist').Position} Position
  * @typedef {import('hast').Element} Element
@@ -44,33 +49,21 @@
  *
  * To do: is `data-sourcepos` typeable?
  *
- * @callback CodeComponent
- * @param {JSX.IntrinsicElements['code'] & ReactMarkdownProps & {inline?: boolean}} props
- * @returns {ReactNode}
+ * @typedef {JSX.IntrinsicElements['code'] & ReactMarkdownProps & {inline?: boolean}} CodeProps
+ * @typedef {JSX.IntrinsicElements['h1'] & ReactMarkdownProps & {level: number}} HeadingProps
+ * @typedef {JSX.IntrinsicElements['li'] & ReactMarkdownProps & {checked: boolean|null, index: number, ordered: boolean}} LiProps
+ * @typedef {JSX.IntrinsicElements['ol'] & ReactMarkdownProps & {depth: number, ordered: true}} OrderedListProps
+ * @typedef {JSX.IntrinsicElements['table'] & ReactMarkdownProps & {style?: Object.<string, unknown>, isHeader: boolean}} TableCellProps
+ * @typedef {JSX.IntrinsicElements['tr'] & ReactMarkdownProps & {isHeader: boolean}} TableRowProps
+ * @typedef {JSX.IntrinsicElements['ul'] & ReactMarkdownProps & {depth: number, ordered: false}} UnorderedListProps
  *
- * @callback HeadingComponent
- * @param {JSX.IntrinsicElements['h1'] & ReactMarkdownProps & {level: number}} props
- * @returns {ReactNode}
- *
- * @callback LiComponent
- * @param {JSX.IntrinsicElements['li'] & ReactMarkdownProps & {checked: boolean|null, index: number, ordered: boolean}} props
- * @returns {ReactNode}
- *
- * @callback OrderedListComponent
- * @param {JSX.IntrinsicElements['ol'] & ReactMarkdownProps & {depth: number, ordered: true}} props
- * @returns {ReactNode}
- *
- * @callback TableCellComponent
- * @param {JSX.IntrinsicElements['table'] & ReactMarkdownProps & {style?: Object.<string, unknown>, isHeader: boolean}} props
- * @returns {ReactNode}
- *
- * @callback TableRowComponent
- * @param {JSX.IntrinsicElements['tr'] & ReactMarkdownProps & {isHeader: boolean}} props
- * @returns {ReactNode}
- *
- * @callback UnorderedListComponent
- * @param {JSX.IntrinsicElements['ul'] & ReactMarkdownProps & {depth: number, ordered: false}} props
- * @returns {ReactNode}
+ * @typedef {ComponentType<CodeProps>} CodeComponent
+ * @typedef {ComponentType<HeadingProps>} HeadingComponent
+ * @typedef {ComponentType<LiProps>} LiComponent
+ * @typedef {ComponentType<OrderedListProps>} OrderedListComponent
+ * @typedef {ComponentType<TableCellProps>} TableCellComponent
+ * @typedef {ComponentType<TableRowProps>} TableRowComponent
+ * @typedef {ComponentType<UnorderedListProps>} UnorderedListComponent
  *
  * @typedef SpecialComponents
  * @property {CodeComponent|ReactMarkdownNames} code

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -1195,6 +1195,7 @@ test('should pass `node` as prop to all non-tag/non-fragment components', () => 
     <Markdown
       children={input}
       components={{
+        // @ts-expect-error JSX types currently only handle element returns not string returns
         h1(props) {
           let text = ''
           visit(props.node, 'text', (child) => {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Changes the `SpecialComponents` to allow them to be non-functional.

My use case is adding styles to the components with Material-UI. Here's an example of what I'm trying to do:

```
export default function Markdown(props: ReactMarkdownOptions) {
  return (
    <ReactMarkdown
      components={{
        li: withStyles(styles)(
          ({
            classes,
            color,
            node,
            ref,
            ...props
          }: JSX.IntrinsicElements['li'] &
            ReactMarkdownProps & {
              checked: boolean | null;
              index: number;
              ordered: boolean;
            } & WithStyles<typeof styles>) => (
            <li className={classes.listItem}>
              <Typography paragraph component="span" {...props} />
            </li>
          ),
        ),
      }}
      remarkPlugins={[remarkGfm]}
      {...props}
    />
  );
}
```

<!--do not edit: pr-->
