### PR TITLE
fix: react-is version

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "comma-separated-tokens": "^2.0.0",
     "prop-types": "^15.0.0",
     "property-information": "^6.0.0",
-    "react-is": "^17.0.0",
+    "react-is": ">=16",
     "remark-parse": "^10.0.0",
     "remark-rehype": "^9.0.0",
     "space-separated-tokens": "^2.0.0",


### PR DESCRIPTION
Allow react-is dependency version to match react and react-dom version

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests

### Description of changes

TODO

<!--do not edit: pr-->
