### PR TITLE
chore(peer-deps): mark @types/react as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
     "@types/react": ">=16",
     "react": ">=16"
   },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`package.json` declares a peerDependency to @types/react. 

this P/R adds the peerDependecyMeta to allow those types to be optional.

Why ?

Without it, we somehow require the @types/react to be installed by the consumer as dependency (npm, yarn will only emit a warning).

But generally @types/* are installed as devDependency (or not at all when js only projects)

Also not that `yarnpkg/doctor` will choke on this (strict check) and emit an error:

![image](https://user-images.githubusercontent.com/259798/139707060-e6c1ccdb-c39e-4f49-8ffd-fe2881851c95.png)

This P/R should fix the error. there's a reproduction too: https://github.com/belgattitude/nextjs-monorepo-example/pull/730
