### PR TITLE
fix: support custom component type from a plugin

### DIFF
--- a/lib/ast-to-react.js
+++ b/lib/ast-to-react.js
@@ -141,6 +141,20 @@ export function childrenToReact(context, node) {
     } else if (child.type === 'raw' && !context.options.skipHtml) {
       // Default behavior is to show (encoded) HTML.
       children.push(child.value)
+    } else if (!context.options.skipHtml && context.options.components) {
+      const {type, ...props} = child
+      /** @type {string} */
+      const component =
+        context.options.components && own.call(context.options.components, type)
+          ? context.options.components[type]
+          : type
+      const hasCustomComponentType = Object.keys(
+        context.options.components
+      ).includes(type)
+      if (hasCustomComponentType) {
+        const key = [type, childIndex].join('-')
+        children.push(React.createElement(component, {...props, key}))
+      }
     }
   }
 

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -1448,7 +1448,7 @@ const pluginCustomComponentType = () => {
           return
         }
 
-        position = position ?? 0
+        position = position || 0
         /** @type {Array<import('unist').Literal<string>>} */
         const definition = []
         let lastIndex = 0


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR fixes a bug: currently using a `rehypePlugin`, that replaces in the string (`props.children`), all the occurrences that apply a regex (for example the regex `/d/` as you can see in the unit tests) by a custom React component defined in `props.components`, it doesn't replace, it removes the content.

Basic usage:

```jsx
    <Markdown
      remarkPlugins={[gfm]}
      // the plugin that replaces the letter 'd' in the string 'abcdef' by the 'customType` component
      rehypePlugins={[pluginCustomComponentType]}
      components={{
         customType: (props) => {
  			return <div>{props.value}-custom</div>
		}
      }}
    >
      {'abcdef'}
    </Markdown>
```

Currently, it outputs: `<p>abcef</p>`, with the PR, it will output: `<p>abc<div>d-custom</div>ef</p>`.
The example is quite simple to stay minimal.

Here is an example of a real-world use case: replace all the `:emoji:` in a string, to use the Emoji react component from [emoji-mart](https://www.npmjs.com/package/emoji-mart), (`:emoji:` being `:wave:`, `:+1:`, etc.).

**Note:** This bug is actually a regression, in `react-markdown@5`, it has the right behavior, but not with the latest released version v7.1.1, it started breaking since v6 apparently.

Friendly ping @ChristianMurphy and @wooorm. :smile:

<!--do not edit: pr-->
