### PR TITLE
Fix `ref` in types

### DIFF
--- a/lib/ast-to-react.js
+++ b/lib/ast-to-react.js
@@ -4,6 +4,11 @@
  */
 
 /**
+ * @template T
+ * @typedef {import('react').ComponentPropsWithoutRef<T>} ComponentPropsWithoutRef<T>
+ */
+
+/**
  * @typedef {import('react').ReactNode} ReactNode
  * @typedef {import('unist').Position} Position
  * @typedef {import('hast').Element} Element
@@ -49,13 +54,13 @@
  *
  * To do: is `data-sourcepos` typeable?
  *
- * @typedef {JSX.IntrinsicElements['code'] & ReactMarkdownProps & {inline?: boolean}} CodeProps
- * @typedef {JSX.IntrinsicElements['h1'] & ReactMarkdownProps & {level: number}} HeadingProps
- * @typedef {JSX.IntrinsicElements['li'] & ReactMarkdownProps & {checked: boolean|null, index: number, ordered: boolean}} LiProps
- * @typedef {JSX.IntrinsicElements['ol'] & ReactMarkdownProps & {depth: number, ordered: true}} OrderedListProps
- * @typedef {JSX.IntrinsicElements['table'] & ReactMarkdownProps & {style?: Record<string, unknown>, isHeader: boolean}} TableCellProps
- * @typedef {JSX.IntrinsicElements['tr'] & ReactMarkdownProps & {isHeader: boolean}} TableRowProps
- * @typedef {JSX.IntrinsicElements['ul'] & ReactMarkdownProps & {depth: number, ordered: false}} UnorderedListProps
+ * @typedef {ComponentPropsWithoutRef<'code'> & ReactMarkdownProps & {inline?: boolean}} CodeProps
+ * @typedef {ComponentPropsWithoutRef<'h1'> & ReactMarkdownProps & {level: number}} HeadingProps
+ * @typedef {ComponentPropsWithoutRef<'li'> & ReactMarkdownProps & {checked: boolean|null, index: number, ordered: boolean}} LiProps
+ * @typedef {ComponentPropsWithoutRef<'ol'> & ReactMarkdownProps & {depth: number, ordered: true}} OrderedListProps
+ * @typedef {ComponentPropsWithoutRef<'table'> & ReactMarkdownProps & {style?: Record<string, unknown>, isHeader: boolean}} TableCellProps
+ * @typedef {ComponentPropsWithoutRef<'tr'> & ReactMarkdownProps & {isHeader: boolean}} TableRowProps
+ * @typedef {ComponentPropsWithoutRef<'ul'> & ReactMarkdownProps & {depth: number, ordered: false}} UnorderedListProps
  *
  * @typedef {ComponentType<CodeProps>} CodeComponent
  * @typedef {ComponentType<HeadingProps>} HeadingComponent

--- a/lib/complex-types.ts
+++ b/lib/complex-types.ts
@@ -1,4 +1,4 @@
-import type {ReactNode, ComponentType} from 'react'
+import type {ReactNode, ComponentType, ComponentPropsWithoutRef} from 'react'
 import type {Position} from 'unist'
 import type {Element} from 'hast'
 
@@ -24,5 +24,5 @@ export interface ReactMarkdownProps {
 export type NormalComponents = {
   [TagName in keyof JSX.IntrinsicElements]:
     | keyof JSX.IntrinsicElements
-    | ComponentType<JSX.IntrinsicElements[TagName] & ReactMarkdownProps>
+    | ComponentType<ComponentPropsWithoutRef<TagName> & ReactMarkdownProps>
 }

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -1161,7 +1161,6 @@ test('should be able to render components with forwardRef in HOC', () => {
   const wrapped = (props) => <a {...props} />
 
   const actual = asHtml(
-    // @ts-expect-error: something up with types for refs.
     <Markdown components={{a: wrapper(wrapped)}}>
       [Link](https://example.com/)
     </Markdown>


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Follow up to https://github.com/remarkjs/react-markdown/issues/666#issuecomment-1001578251 removing `ref` from element props.
Leverages `ComponentPropsWithoutRef` which is a wrapper around `IntrinsicElements` which picks component properties from it.

<!--do not edit: pr-->
