### PR TITLE
Add support for passing options to `remark-rehype`

### DIFF
--- a/lib/react-markdown.js
+++ b/lib/react-markdown.js
@@ -13,6 +13,7 @@
  * @property {PluggableList} [plugins=[]] **deprecated**: use `remarkPlugins` instead
  * @property {PluggableList} [remarkPlugins=[]]
  * @property {PluggableList} [rehypePlugins=[]]
+ * @property {import('remark-rehype').Options} [rehypeOptions={}]
  *
  * @typedef LayoutOptions
  * @property {string} [className]
@@ -87,7 +88,10 @@ export function ReactMarkdown(options) {
     .use(remarkParse)
     // TODO: deprecate `plugins` in v8.0.0.
     .use(options.remarkPlugins || options.plugins || [])
-    .use(remarkRehype, {allowDangerousHtml: true})
+    .use(remarkRehype, {
+      ...options.rehypeOptions,
+      allowDangerousHtml: true
+    })
     .use(options.rehypePlugins || [])
     .use(rehypeFilter, options)
 

--- a/lib/react-markdown.js
+++ b/lib/react-markdown.js
@@ -13,7 +13,7 @@
  * @property {PluggableList} [plugins=[]] **deprecated**: use `remarkPlugins` instead
  * @property {PluggableList} [remarkPlugins=[]]
  * @property {PluggableList} [rehypePlugins=[]]
- * @property {import('remark-rehype').Options} [rehypeOptions={}]
+ * @property {import('remark-rehype').Options} [remarkRehypeOptions={}]
  *
  * @typedef LayoutOptions
  * @property {string} [className]
@@ -89,7 +89,7 @@ export function ReactMarkdown(options) {
     // TODO: deprecate `plugins` in v8.0.0.
     .use(options.remarkPlugins || options.plugins || [])
     .use(remarkRehype, {
-      ...options.rehypeOptions,
+      ...options.remarkRehypeOptions,
       allowDangerousHtml: true
     })
     .use(options.rehypePlugins || [])

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "property-information": "^6.0.0",
     "react-is": "^17.0.0",
     "remark-parse": "^10.0.0",
-    "remark-rehype": "^9.0.0",
+    "remark-rehype": "^10.0.0",
     "space-separated-tokens": "^2.0.0",
     "style-to-object": "^0.3.0",
     "unified": "^10.0.0",

--- a/readme.md
+++ b/readme.md
@@ -175,8 +175,8 @@ The default export is `ReactMarkdown`.
     list of [remark plugins][remark-plugins] to use
 *   `rehypePlugins` (`Array<Plugin>`, default: `[]`)\
     list of [rehype plugins][rehype-plugins] to use
-*   `rehypeOptions` ([`RemarkRehype.Options`][remark-rehype-options], default: `{}`)\
-    options to pass through to [remark-rehype][]
+*   `remarkRehypeOptions` (`Object?`, default: `undefined`)\
+    options to pass through to [`remark-rehype`][remark-rehype]
 *   `className` (`string?`)\
     wrap the markdown in a `div` with this class name
 *   `skipHtml` (`boolean`, default: `false`)\
@@ -736,8 +736,6 @@ abide by its terms.
 [rehype-plugins]: https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins
 
 [remark-rehype]: https://github.com/remarkjs/remark-rehype
-
-[remark-rehype-options]: https://github.com/remarkjs/remark-rehype#options
 
 [awesome-remark]: https://github.com/remarkjs/awesome-remark
 

--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,8 @@ The default export is `ReactMarkdown`.
     list of [remark plugins][remark-plugins] to use
 *   `rehypePlugins` (`Array<Plugin>`, default: `[]`)\
     list of [rehype plugins][rehype-plugins] to use
+*   `rehypeOptions` ([`RemarkRehype.Options`][remark-rehype-options], default: `{}`)\
+    options to pass through to [remark-rehype][]
 *   `className` (`string?`)\
     wrap the markdown in a `div` with this class name
 *   `skipHtml` (`boolean`, default: `false`)\
@@ -732,6 +734,10 @@ abide by its terms.
 [remark-plugins]: https://github.com/remarkjs/remark/blob/main/doc/plugins.md#list-of-plugins
 
 [rehype-plugins]: https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins
+
+[remark-rehype]: https://github.com/remarkjs/remark-rehype
+
+[remark-rehype-options]: https://github.com/remarkjs/remark-rehype#options
 
 [awesome-remark]: https://github.com/remarkjs/awesome-remark
 

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -874,6 +874,25 @@ test('should render image references', () => {
   )
 })
 
+test('should render footnote with custom options', () => {
+  const input = [
+    'This is a statement[^1] with a citation.',
+    '',
+    '[^1]: This is a footnote for the citation.'
+  ].join('\n')
+
+  assert.equal(
+    asHtml(
+      <Markdown
+        children={input}
+        remarkPlugins={[gfm]}
+        rehypeOptions={{clobberPrefix: 'user-content-'}}
+      />
+    ),
+    '<p>This is a statement<sup><a href="#user-content-fn-1" id="user-content-fnref-1" data-footnote-ref="true" aria-describedby="footnote-label">1</a></sup> with a citation.</p>\n<section data-footnotes="true" class="footnotes"><h2 id="footnote-label" class="sr-only">Footnotes</h2>\n<ol>\n<li id="user-content-fn-1">\n<p>This is a footnote for the citation. <a href="#user-content-fnref-1" data-footnote-backref="true" class="data-footnote-backref" aria-label="Back to content">↩</a></p>\n</li>\n</ol>\n</section>'
+  )
+})
+
 test('should support definitions with funky keys', () => {
   const input =
     '[][__proto__] and [][constructor]\n\n[__proto__]: a\n[constructor]: b'

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -886,10 +886,10 @@ test('should render footnote with custom options', () => {
       <Markdown
         children={input}
         remarkPlugins={[gfm]}
-        rehypeOptions={{clobberPrefix: 'user-content-'}}
+        remarkRehypeOptions={{clobberPrefix: 'main-'}}
       />
     ),
-    '<p>This is a statement<sup><a href="#user-content-fn-1" id="user-content-fnref-1" data-footnote-ref="true" aria-describedby="footnote-label">1</a></sup> with a citation.</p>\n<section data-footnotes="true" class="footnotes"><h2 id="footnote-label" class="sr-only">Footnotes</h2>\n<ol>\n<li id="user-content-fn-1">\n<p>This is a footnote for the citation. <a href="#user-content-fnref-1" data-footnote-backref="true" class="data-footnote-backref" aria-label="Back to content">↩</a></p>\n</li>\n</ol>\n</section>'
+    '<p>This is a statement<sup><a href="#main-fn-1" id="main-fnref-1" data-footnote-ref="true" aria-describedby="footnote-label">1</a></sup> with a citation.</p>\n<section data-footnotes="true" class="footnotes"><h2 id="footnote-label" class="sr-only">Footnotes</h2>\n<ol>\n<li id="main-fn-1">\n<p>This is a footnote for the citation. <a href="#main-fnref-1" data-footnote-backref="true" class="data-footnote-backref" aria-label="Back to content">↩</a></p>\n</li>\n</ol>\n</section>'
   )
 })
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR updates `remark-rehype` to v10, and adds options passthrough to `remark-rehype`.
This is to enable new options such as `clobberPrefix`, which is needed when rendering more than one Markdown document on a page (e.g. comments).
Attempted to follow the guidelines and current code structure as much as I could.

<!--do not edit: pr-->
