### PR TITLE
Fix TypeScript bug by adding workaround

### DIFF
--- a/lib/react-markdown.js
+++ b/lib/react-markdown.js
@@ -12,7 +12,7 @@
  * @typedef PluginOptions
  * @property {PluggableList} [remarkPlugins=[]]
  * @property {PluggableList} [rehypePlugins=[]]
- * @property {import('remark-rehype').Options} [remarkRehypeOptions={}]
+ * @property {import('remark-rehype').Options | undefined} [remarkRehypeOptions={}]
  *
  * @typedef LayoutOptions
  * @property {string} [className]


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Follow-up to https://github.com/remarkjs/react-markdown/pull/675. Adds `| undefined` as suggested in https://github.com/microsoft/TypeScript/issues/48242#issuecomment-1067348119.

Fixes this build error:
```
ERROR in ../../.yarn/__virtual__/react-markdown-virtual-1089d10e66/0/cache/react-markdown-npm-8.0.0-3d725f3756-61412ecd18.zip/node_modules/react-markdown/lib/react-markdown.d.ts 47:32-56
TS2307: Cannot find module 'mdast-util-to-hast/lib' or its corresponding type declarations.
    45 |   remarkPlugins?: import('unified').PluggableList | undefined
    46 |   rehypePlugins?: import('unified').PluggableList | undefined
  > 47 |   remarkRehypeOptions?: import('mdast-util-to-hast/lib').Options | undefined
       |                                ^^^^^^^^^^^^^^^^^^^^^^^^
    48 | }
    49 | export type LayoutOptions = {
    50 |   className?: string | undefined
```

<!--do not edit: pr-->
