### PR TITLE
Fix remark/rehypePlugins prop-types to support nested array arguments

### DIFF
--- a/lib/react-markdown.js
+++ b/lib/react-markdown.js
@@ -126,6 +126,28 @@ export function ReactMarkdown(options) {
 
 ReactMarkdown.defaultProps = {transformLinkUri: uriTransformer}
 
+/** Allowed arguments to nested array arguments to remark/rehypePlugins */
+function allowedScalarArgumentsToPlugins(val) {
+  const t = typeof val
+  if (t === 'boolean' || t === 'string' || t === 'number' || t === 'function') {
+    return null
+  } else {
+    return new Error('Invalid type for plugin array argument')
+  }
+}
+
+/** Allowed types for remark/rehypePlugins */
+const pluginPropTypes = PropTypes.arrayOf(
+  PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.func,
+    PropTypes.arrayOf(allowedScalarArgumentsToPlugins)
+  ])
+)
+
 ReactMarkdown.propTypes = {
   // Core options:
   children: PropTypes.string,
@@ -137,20 +159,8 @@ ReactMarkdown.propTypes = {
   disallowedElements: PropTypes.arrayOf(PropTypes.string),
   unwrapDisallowed: PropTypes.bool,
   // Plugin options:
-  remarkPlugins: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.object,
-      PropTypes.func,
-      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.func]))
-    ])
-  ),
-  rehypePlugins: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.object,
-      PropTypes.func,
-      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.func]))
-    ])
-  ),
+  remarkPlugins: pluginPropTypes,
+  rehypePlugins: pluginPropTypes,
   // Transform options:
   sourcePos: PropTypes.bool,
   rawSourcePos: PropTypes.bool,


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR addresses the discussion https://github.com/remarkjs/remark/discussions/945

Before this PR, passing a plugin such as

```
[ myPluginFn, ['hello', 'world'] ]
```

would fail prop-types validation. This PR extends the plugin prop-types to allow other scalar values, and also to better support the kind of tuple typing that you want to allow.

This does not seem to be supported by prop-types:
```
PropTypes.arrayOf(PropTypes.oneOf(PropTypes.string, PropTypes.array(PropTypes.string)))
```

instead, we will need to use a custom validator for the nested arrays.

<!--do not edit: pr-->
