### PR TITLE
Fix prop types of plugins

### DIFF
--- a/lib/react-markdown.js
+++ b/lib/react-markdown.js
@@ -141,14 +141,38 @@ ReactMarkdown.propTypes = {
     PropTypes.oneOfType([
       PropTypes.object,
       PropTypes.func,
-      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.func]))
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.bool,
+          PropTypes.string,
+          PropTypes.object,
+          PropTypes.func,
+          PropTypes.arrayOf(
+            // prettier-ignore
+            // type-coverage:ignore-next-line
+            PropTypes.any
+          )
+        ])
+      )
     ])
   ),
   rehypePlugins: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.object,
       PropTypes.func,
-      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.func]))
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.bool,
+          PropTypes.string,
+          PropTypes.object,
+          PropTypes.func,
+          PropTypes.arrayOf(
+            // prettier-ignore
+            // type-coverage:ignore-next-line
+            PropTypes.any
+          )
+        ])
+      )
     ])
   ),
   // Transform options:

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -1424,4 +1424,50 @@ test('should crash on a plugin replacing `root`', () => {
   }, /Expected a `root` node/)
 })
 
+test('should support remark plugins with array parameter', async () => {
+  const error = console.error
+  /** @type {string} */
+  let message = ''
+
+  console.error = (/** @type {string} */ d) => {
+    message = d
+  }
+
+  const input = 'a'
+  /** @type {import('unified').Plugin<Array<Array<string>>, Root>} */
+  const plugin = () => () => {}
+
+  const actual = asHtml(
+    <Markdown children={input} remarkPlugins={[[plugin, ['foo', 'bar']]]} />
+  )
+  const expected = '<p>a</p>'
+  assert.equal(actual, expected)
+
+  assert.not.match(message, /Warning: Failed/, 'Prop types should be valid')
+  console.error = error
+})
+
+test('should support rehype plugins with array parameter', async () => {
+  const error = console.error
+  /** @type {string} */
+  let message = ''
+
+  console.error = (/** @type {string} */ d) => {
+    message = d
+  }
+
+  const input = 'a'
+  /** @type {import('unified').Plugin<Array<Array<string>>, Root>} */
+  const plugin = () => () => {}
+
+  const actual = asHtml(
+    <Markdown children={input} rehypePlugins={[[plugin, ['foo', 'bar']]]} />
+  )
+  const expected = '<p>a</p>'
+  assert.equal(actual, expected)
+
+  assert.not.match(message, /Warning: Failed/, 'Prop types should be valid')
+  console.error = error
+})
+
 test.run()


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR extends the prop-types of rehypePlugins and remarkPlugins to support strings and arrays of strings. See https://github.com/remarkjs/remark/discussions/945

<!--do not edit: pr-->
