### PR TITLE
Add clarification of `alt` on `img` in docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -571,7 +571,8 @@ Other remark or rehype plugins that add support for new constructs will also
 work with `react-markdown`.
 
 The props that are passed are what you probably would expect: an `a` (link) will
-get `href` (and `title`) props, and `img` (image) an `src`, `alt` and `title`, etc.
+get `href` (and `title`) props, and `img` (image) an `src`, `alt` and `title`,
+etc.
 There are some extra props passed.
 
 *   `code`

--- a/readme.md
+++ b/readme.md
@@ -571,7 +571,7 @@ Other remark or rehype plugins that add support for new constructs will also
 work with `react-markdown`.
 
 The props that are passed are what you probably would expect: an `a` (link) will
-get `href` (and `title`) props, and `img` (image) an `src` (and `title`), etc.
+get `href` (and `title`) props, and `img` (image) an `src`, `alt` and `title`, etc.
 There are some extra props passed.
 
 *   `code`


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Included `alt` as one of the attributes expected in the `img` component as this component outputs both `alt` AND `title`. Not having both can be misleading specially since `alt` is what's most often/easily used when creating an image in markdown `[!alt](src "title")`. The use of alt over title comes not only from practicality but also due to accessibility. Additionally, removed parenthesis as it read better now that there wasn't just one item.

<!--do not edit: pr-->
