### PR TITLE
Make minified source available to all tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
   "main": "index.js",
   "types": "index.d.ts",
   "unpkg": "react-markdown.min.js",
+  "exports": {
+    "require": "./react-markdown.min.js",
+    "default": "./index.js"
+  },
   "files": [
     "lib/",
     "index.d.ts",


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests (not applicable)

### Description of changes

Support other tools which cannot work with ES Modules (e.g. Jest). The necessary code is already available but using a proprietary key in package.json (for unpkg). This adds standards-compliant config to make it available to other tooling which needs it.

<!--do not edit: pr-->
