### PR TITLE
fix "th" and "td" type definitions based off native elements

### DIFF
--- a/lib/ast-to-react.js
+++ b/lib/ast-to-react.js
@@ -58,7 +58,8 @@
  * @typedef {ComponentPropsWithoutRef<'h1'> & ReactMarkdownProps & {level: number}} HeadingProps
  * @typedef {ComponentPropsWithoutRef<'li'> & ReactMarkdownProps & {checked: boolean|null, index: number, ordered: boolean}} LiProps
  * @typedef {ComponentPropsWithoutRef<'ol'> & ReactMarkdownProps & {depth: number, ordered: true}} OrderedListProps
- * @typedef {ComponentPropsWithoutRef<'table'> & ReactMarkdownProps & {style?: Record<string, unknown>, isHeader: boolean}} TableCellProps
+ * @typedef {ComponentPropsWithoutRef<'td'> & ReactMarkdownProps & {style?: Record<string, unknown>, isHeader: false}} TableDataCellProps
+ * @typedef {ComponentPropsWithoutRef<'th'> & ReactMarkdownProps & {style?: Record<string, unknown>, isHeader: true}} TableHeaderCellProps
  * @typedef {ComponentPropsWithoutRef<'tr'> & ReactMarkdownProps & {isHeader: boolean}} TableRowProps
  * @typedef {ComponentPropsWithoutRef<'ul'> & ReactMarkdownProps & {depth: number, ordered: false}} UnorderedListProps
  *
@@ -66,7 +67,8 @@
  * @typedef {ComponentType<HeadingProps>} HeadingComponent
  * @typedef {ComponentType<LiProps>} LiComponent
  * @typedef {ComponentType<OrderedListProps>} OrderedListComponent
- * @typedef {ComponentType<TableCellProps>} TableCellComponent
+ * @typedef {ComponentType<TableDataCellProps>} TableDataCellComponent
+ * @typedef {ComponentType<TableHeaderCellProps>} TableHeaderCellComponent
  * @typedef {ComponentType<TableRowProps>} TableRowComponent
  * @typedef {ComponentType<UnorderedListProps>} UnorderedListComponent
  *
@@ -80,8 +82,8 @@
  * @property {HeadingComponent|ReactMarkdownNames} h6
  * @property {LiComponent|ReactMarkdownNames} li
  * @property {OrderedListComponent|ReactMarkdownNames} ol
- * @property {TableCellComponent|ReactMarkdownNames} td
- * @property {TableCellComponent|ReactMarkdownNames} th
+ * @property {TableDataCellComponent|ReactMarkdownNames} td
+ * @property {TableHeaderCellComponent|ReactMarkdownNames} th
  * @property {TableRowComponent|ReactMarkdownNames} tr
  * @property {UnorderedListComponent|ReactMarkdownNames} ul
  *


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Addresses #713 . Specify "th" and "td" props based off html elements. `ast-to-react.d.ts` will look like:

```
export type TableDataCellProps = ComponentPropsWithoutRef<'td'> &
  ReactMarkdownProps & {
    style?: Record<string, unknown>
    isHeader: false
  }
export type TableHeaderCellProps = ComponentPropsWithoutRef<'th'> &
  ReactMarkdownProps & {
    style?: Record<string, unknown>
    isHeader: true
  }
(...)

export type TableDataCellComponent = ComponentType<TableDataCellProps>
export type TableHeaderCellComponent = ComponentType<TableHeaderCellProps>
(...)

export type SpecialComponents = {
  (...)
  td: TableDataCellComponent | ReactMarkdownNames
  th: TableHeaderCellComponent | ReactMarkdownNames
}
```

<!--do not edit: pr-->
