### PR TITLE
Fix typo in `plugins` -> `remarkPlugins` deprecation message

### DIFF
--- a/lib/react-markdown.js
+++ b/lib/react-markdown.js
@@ -41,7 +41,7 @@ const changelog =
 
 /** @type {Record<string, Deprecation>} */
 const deprecated = {
-  plugins: {to: 'plugins', id: 'change-plugins-to-remarkplugins'},
+  plugins: {to: 'remarkPlugins', id: 'change-plugins-to-remarkplugins'},
   renderers: {to: 'components', id: 'change-renderers-to-components'},
   astPlugins: {id: 'remove-buggy-html-in-markdown-parser'},
   allowDangerousHtml: {id: 'remove-buggy-html-in-markdown-parser'},


### PR DESCRIPTION
Signed-off-by: Marc Espín <mespinsanz@gmail.com>

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Change the `to` of the plugins deprecation message. It should be `remarkPlugins` instead of `plugins`. It doesn't make sense to migrate from `plugins` to `plugins`.

This is the message that I got:

![image](https://user-images.githubusercontent.com/38158676/207712263-8c93bb2f-730d-49ab-87c9-0b036bb7f607.png)

<!--do not edit: pr-->