### PR TITLE
Improve README syntax highlight example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -354,14 +354,14 @@ ReactDom.render(
         const match = /language-(\w+)/.exec(className || '')
         return !inline && match ? (
           <SyntaxHighlighter
+            {...props}
             children={String(children).replace(/\n$/, '')}
             style={dark}
             language={match[1]}
             PreTag="div"
-            {...props}
           />
         ) : (
-          <code className={className} {...props}>
+          <code {...props} className={className}>
             {children}
           </code>
         )


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Improves README syntax highlighting example. The current example produces a TypeScript error by default. See here: https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/479#issuecomment-1267772279 

<!--do not edit: pr-->
