### PR TITLE
Changed passing children by props to nest between tags in docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ import remarkGfm from 'remark-gfm'
 const markdown = `Just a link: https://reactjs.com.`
 
 ReactDom.render(
-  <ReactMarkdown remarkPlugins={[remarkGfm]} >
+  <ReactMarkdown remarkPlugins={[remarkGfm]}>
     {markdown}
   </ReactMarkdown>,
   document.body
@@ -251,7 +251,7 @@ A table:
 `
 
 ReactDom.render(
-  <ReactMarkdown remarkPlugins={[remarkGfm]} >{markdown}</ReactMarkdown>,
+  <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>,
   document.body
 )
 ```
@@ -369,7 +369,7 @@ ReactDom.render(
       }
     }}
   >
-  {markdown}
+    {markdown}
   </ReactMarkdown>,
   document.body
 )
@@ -408,7 +408,9 @@ ReactDom.render(
   <ReactMarkdown
     remarkPlugins={[remarkMath]}
     rehypePlugins={[rehypeKatex]}
-  >{`The lift coefficient ($C_L$) is a dimensionless coefficient.`}</ReactMarkdown>,
+  >
+    {`The lift coefficient ($C_L$) is a dimensionless coefficient.`}
+  </ReactMarkdown>,
   document.body
 )
 ```
@@ -526,7 +528,7 @@ Some *emphasis* and <strong>strong</strong>!
 </div>`
 
 ReactDom.render(
-  <ReactMarkdown rehypePlugins={[rehypeRaw]} >{input}</ReactMarkdown>,
+  <ReactMarkdown rehypePlugins={[rehypeRaw]}>{input}</ReactMarkdown>,
   document.body
 )
 ```

--- a/readme.md
+++ b/readme.md
@@ -408,7 +408,7 @@ ReactDom.render(
   <ReactMarkdown
     remarkPlugins={[remarkMath]}
     rehypePlugins={[rehypeKatex]}
-  >{`The lift coefficient ($C_L$) is a dimensionless coefficient.`}</>,
+  >{`The lift coefficient ($C_L$) is a dimensionless coefficient.`}</ReactMarkdown>,
   document.body
 )
 ```

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,9 @@ import remarkGfm from 'remark-gfm'
 const markdown = `Just a link: https://reactjs.com.`
 
 ReactDom.render(
-  <ReactMarkdown children={markdown} remarkPlugins={[remarkGfm]} />,
+  <ReactMarkdown remarkPlugins={[remarkGfm]} >
+    {markdown}
+  </ReactMarkdown>,
   document.body
 )
 ```
@@ -249,7 +251,7 @@ A table:
 `
 
 ReactDom.render(
-  <ReactMarkdown children={markdown} remarkPlugins={[remarkGfm]} />,
+  <ReactMarkdown remarkPlugins={[remarkGfm]} >{markdown}</ReactMarkdown>,
   document.body
 )
 ```
@@ -348,7 +350,6 @@ console.log('It works!')
 
 ReactDom.render(
   <ReactMarkdown
-    children={markdown}
     components={{
       code({node, inline, className, children, ...props}) {
         const match = /language-(\w+)/.exec(className || '')
@@ -367,7 +368,9 @@ ReactDom.render(
         )
       }
     }}
-  />,
+  >
+  {markdown}
+  </ReactMarkdown>,
   document.body
 )
 ```
@@ -403,10 +406,9 @@ import 'katex/dist/katex.min.css' // `rehype-katex` does not import the CSS for 
 
 ReactDom.render(
   <ReactMarkdown
-    children={`The lift coefficient ($C_L$) is a dimensionless coefficient.`}
     remarkPlugins={[remarkMath]}
     rehypePlugins={[rehypeKatex]}
-  />,
+  >{`The lift coefficient ($C_L$) is a dimensionless coefficient.`}</>,
   document.body
 )
 ```
@@ -524,7 +526,7 @@ Some *emphasis* and <strong>strong</strong>!
 </div>`
 
 ReactDom.render(
-  <ReactMarkdown rehypePlugins={[rehypeRaw]} children={input} />,
+  <ReactMarkdown rehypePlugins={[rehypeRaw]} >{input}</ReactMarkdown>,
   document.body
 )
 ```


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes
Some of the examples mentioned in the readme are passing children as props which gives a ESLint error of `react/no-children-prop` on Next.js 13 with ESLint configured
```javascript
<ReactMarkdown children={markdown}  />
```
```
yarn run v1.22.19
$ next build

Failed to compile.

./pages/blogs/[slug].tsx
72:13  Error: Do not pass children as props. Instead, nest children between the opening and closing tags.  react/no-children-prop

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
error Command failed with exit code 1.
```
Updated the examples to nest child component between the opening and closing tags.
```javascript
<ReactMarkdown>{markdown}</ReactMarkdown>
```
<!--do not edit: pr-->
