### PR TITLE
Removing `linkTarget` option

### DIFF
--- a/lib/ast-to-react.js
+++ b/lib/ast-to-react.js
@@ -42,14 +42,6 @@
  * @param {string?} title
  * @returns {string}
  *
- * @typedef {import('react').HTMLAttributeAnchorTarget} TransformLinkTargetType
- *
- * @callback TransformLinkTarget
- * @param {string} href
- * @param {Array<ElementContent>} children
- * @param {string?} title
- * @returns {TransformLinkTargetType|undefined}
- *
  * @typedef {keyof JSX.IntrinsicElements} ReactMarkdownNames
  *
  * To do: is `data-sourcepos` typeable?
@@ -96,7 +88,6 @@
  * @property {boolean} [includeElementIndex=false]
  * @property {null|false|TransformLink} [transformLinkUri]
  * @property {TransformImage} [transformImageUri]
- * @property {TransformLinkTargetType|TransformLinkTarget} [linkTarget]
  * @property {Components} [components]
  */
 
@@ -222,17 +213,6 @@ function toReact(context, node, index, parent) {
   }
 
   properties.key = index
-
-  if (name === 'a' && options.linkTarget) {
-    properties.target =
-      typeof options.linkTarget === 'function'
-        ? options.linkTarget(
-            String(properties.href || ''),
-            node.children,
-            typeof properties.title === 'string' ? properties.title : null
-          )
-        : options.linkTarget
-  }
 
   if (name === 'a' && transform) {
     properties.href = transform(

--- a/lib/react-markdown.js
+++ b/lib/react-markdown.js
@@ -178,7 +178,6 @@ ReactMarkdown.propTypes = {
   skipHtml: PropTypes.bool,
   includeElementIndex: PropTypes.bool,
   transformLinkUri: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
-  linkTarget: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   transformImageUri: PropTypes.func,
   components: PropTypes.object
 }

--- a/readme.md
+++ b/readme.md
@@ -203,8 +203,6 @@ The default export is `ReactMarkdown`.
     extract (unwrap) the children of not allowed elements, by default, when
     `strong` is disallowed, it and it’s children are dropped, but with
     `unwrapDisallowed` the element itself is replaced by its children
-*   `linkTarget` (`string` or `(href, children, title) => string`, optional)\
-    target to use on links (such as `_blank` for `<a target="_blank"…`)
 *   `transformLinkUri` (`(href, children, title) => string`, default:
     [`uriTransformer`][uri-transformer], optional)\
     change URLs on links, pass `null` to allow all URLs, see [security][]
@@ -632,8 +630,6 @@ Optionally, components will also receive:
     — see `rawSourcePos` option
 *   `index` and `siblingCount` (`number`)
     — see `includeElementIndex` option
-*   `target` on `a` (`string`)
-    — see `linkTarget` option
 
 ## Security
 

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -231,62 +231,6 @@ test('should handle titles of links', () => {
   assert.equal(actual, '<p>Empty: <a href="#" title="x"></a></p>')
 })
 
-test('should use target attribute for links if specified', () => {
-  const input = 'This is [a link](https://espen.codes/) to Espen.Codes.'
-  const actual = asHtml(<Markdown children={input} linkTarget="_blank" />)
-  assert.equal(
-    actual,
-    '<p>This is <a href="https://espen.codes/" target="_blank">a link</a> to Espen.Codes.</p>'
-  )
-})
-
-test('should call function to get target attribute for links if specified', () => {
-  const input = 'This is [a link](https://espen.codes/) to Espen.Codes.'
-  const actual = asHtml(
-    <Markdown
-      children={input}
-      linkTarget={(uri) => (uri.startsWith('http') ? '_blank' : undefined)}
-    />
-  )
-  assert.equal(
-    actual,
-    '<p>This is <a href="https://espen.codes/" target="_blank">a link</a> to Espen.Codes.</p>'
-  )
-})
-
-test('should handle links with custom target transformer', () => {
-  const input = 'Empty: []()'
-
-  const actual = asHtml(
-    <Markdown
-      children={input}
-      linkTarget={(uri, _, title) => {
-        assert.equal(uri, '', '`uri` should be an empty string')
-        assert.equal(title, null, '`title` should be null')
-        return undefined
-      }}
-    />
-  )
-
-  assert.equal(actual, '<p>Empty: <a href=""></a></p>')
-})
-
-test('should handle links w/ titles with custom target transformer', () => {
-  const input = 'Empty: [](a "b")'
-
-  const actual = asHtml(
-    <Markdown
-      children={input}
-      linkTarget={(_, _1, title) => {
-        assert.equal(title, 'b', '`title` should be given')
-        return undefined
-      }}
-    />
-  )
-
-  assert.equal(actual, '<p>Empty: <a href="a" title="b"></a></p>')
-})
-
 test('should support images without alt, url, or title', () => {
   const input = '![]()'
   const actual = asHtml(<Markdown children={input} transformLinkUri={null} />)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Following the discussion in https://github.com/remarkjs/react-markdown/pull/761, I removed the redundant `linkTarget` prop.
This functionality can still be applied using plugins, or the `components` prop.

<!--do not edit: pr-->
