### PR TITLE
Remove support for `className` prop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,23 +2,6 @@
 
 All notable changes will be documented in this file.
 
-## 9.0.1
-
-### Deprecate `className`
-
-The `className` prop was deprecated.
-Not only does the `className` prop add the `className` prop, it also implies a
-wrapper `<div>` will be created.
-Instead, you should wrap the content in a `<div>` manually.
-
-```jsx
-<div className={className}>
-  <Markdown>
-    {children}
-  </Markdown>
-</div>
-```
-
 ## 9.0.0 - 2023-09-27
 
 *   [`b67d714`](https://github.com/remarkjs/react-markdown/commit/b67d714)

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,23 @@
 
 All notable changes will be documented in this file.
 
+## 9.0.1
+
+### Deprecate `className`
+
+The `className` prop was deprecated.
+Not only does the `className` prop add the `className` prop, it also implies a
+wrapper `<div>` will be created.
+Instead, you should wrap the content in a `<div>` manually.
+
+```jsx
+<div className={className}>
+  <Markdown>
+    {children}
+  </Markdown>
+</div>
+```
+
 ## 9.0.0 - 2023-09-27
 
 *   [`b67d714`](https://github.com/remarkjs/react-markdown/commit/b67d714)

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
 
 /**
  * @typedef {import('hast').Element} Element
- * @typedef {import('hast').ElementContent} ElementContent
  * @typedef {import('hast').Parents} Parents
  * @typedef {import('hast').Root} Root
  * @typedef {import('hast-util-to-jsx-runtime').Components} JsxRuntimeComponents

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,6 +116,7 @@ const deprecations = [
     id: 'replace-allownode-allowedtypes-and-disallowedtypes',
     to: 'allowedElements'
   },
+  {from: 'className', id: 'deprecate-classname'},
   {
     from: 'disallowedTypes',
     id: 'replace-allownode-allowedtypes-and-disallowedtypes',
@@ -266,8 +267,8 @@ export function Markdown(options) {
       let remove = allowedElements
         ? !allowedElements.includes(node.tagName)
         : disallowedElements
-        ? disallowedElements.includes(node.tagName)
-        : false
+          ? disallowedElements.includes(node.tagName)
+          : false
 
       if (!remove && allowElement && typeof index === 'number') {
         remove = !allowElement(node, index, parent)

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@
 /**
  * @typedef {import('hast').Element} Element
  * @typedef {import('hast').ElementContent} ElementContent
- * @typedef {import('hast').Nodes} Nodes
  * @typedef {import('hast').Parents} Parents
  * @typedef {import('hast').Root} Root
  * @typedef {import('hast-util-to-jsx-runtime').Components} JsxRuntimeComponents
@@ -47,8 +46,6 @@
  *   cannot combine w/ `disallowedElements`.
  * @property {string | null | undefined} [children]
  *   Markdown.
- * @property {string | null | undefined} [className]
- *   Wrap in a `div` with this class name.
  * @property {Components | null | undefined} [components]
  *   Map tag names to components.
  * @property {ReadonlyArray<string> | null | undefined} [disallowedElements]
@@ -150,7 +147,6 @@ export function Markdown(options) {
   const allowedElements = options.allowedElements
   const allowElement = options.allowElement
   const children = options.children || ''
-  const className = options.className
   const components = options.components
   const disallowedElements = options.disallowedElements
   const rehypePlugins = options.rehypePlugins || emptyPlugins
@@ -205,21 +201,7 @@ export function Markdown(options) {
   }
 
   const mdastTree = processor.parse(file)
-  /** @type {Nodes} */
-  let hastTree = processor.runSync(mdastTree, file)
-
-  // Wrap in `div` if there’s a class name.
-  if (className) {
-    hastTree = {
-      type: 'element',
-      tagName: 'div',
-      properties: {className},
-      // Assume no doctypes.
-      children: /** @type {Array<ElementContent>} */ (
-        hastTree.type === 'root' ? hastTree.children : [hastTree]
-      )
-    }
-  }
+  const hastTree = processor.runSync(mdastTree, file)
 
   visit(hastTree, transform)
 
@@ -267,8 +249,8 @@ export function Markdown(options) {
       let remove = allowedElements
         ? !allowedElements.includes(node.tagName)
         : disallowedElements
-          ? disallowedElements.includes(node.tagName)
-          : false
+        ? disallowedElements.includes(node.tagName)
+        : false
 
       if (!remove && allowElement && typeof index === 'number') {
         remove = !allowElement(node, index, parent)

--- a/readme.md
+++ b/readme.md
@@ -256,8 +256,6 @@ Configuration (TypeScript type).
     cannot combine w/ `disallowedElements`
 *   `children` (`string`, optional)
     — markdown
-*   `className` (`string`, optional)
-    — wrap in a `div` with this class name
 *   `components` ([`Components`][api-components], optional)
     — map tag names to components
 *   `disallowedElements` (`Array<string>`, default: `[]`)

--- a/test.jsx
+++ b/test.jsx
@@ -61,32 +61,6 @@ test('react-markdown', async function (t) {
     }, /Unexpected `allowDangerousHtml` prop, remove it/)
   })
 
-  await t.test('should support `className`', function () {
-    assert.equal(
-      asHtml(<Markdown children="a" className="md" />),
-      '<div class="md"><p>a</p></div>'
-    )
-  })
-
-  await t.test('should support `className` (if w/o root)', function () {
-    assert.equal(
-      asHtml(
-        <Markdown children={'a'} className="b" rehypePlugins={[plugin]} />
-      ),
-      '<div class="b"></div>'
-    )
-
-    function plugin() {
-      /**
-       * @returns {Root}
-       */
-      return function () {
-        // @ts-expect-error: check how non-roots are handled.
-        return {type: 'comment', value: 'things!'}
-      }
-    }
-  })
-
   await t.test('should support a block quote', function () {
     assert.equal(
       asHtml(<Markdown children="> a" />),


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This deprecates the `className` prop, but does not remove it yet. Users should wrap the `<Markdown>` component inside a `<div>` manually instead.

Closes #781

<!--do not edit: pr-->
