### PR TITLE
Refactor to use `@import` to import types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,15 +2,11 @@
 /// <reference types="mdast-util-to-hast" />
 
 /**
- * @typedef {import('hast').Element} Element
- * @typedef {import('hast').ElementContent} ElementContent
- * @typedef {import('hast').Nodes} Nodes
- * @typedef {import('hast').Parents} Parents
- * @typedef {import('hast').Root} Root
- * @typedef {import('hast-util-to-jsx-runtime').Components} JsxRuntimeComponents
- * @typedef {import('remark-rehype').Options} RemarkRehypeOptions
- * @typedef {import('unist-util-visit').BuildVisitor<Root>} Visitor
- * @typedef {import('unified').PluggableList} PluggableList
+ * @import {Element, ElementContent, Nodes, Parents, Root} from 'hast'
+ * @import {Components as JsxRuntimeComponents} from 'hast-util-to-jsx-runtime'
+ * @import {Options as RemarkRehypeOptions} from 'remark-rehype'
+ * @import {BuildVisitor} from 'unist-util-visit'
+ * @import {PluggableList} from 'unified'
  */
 
 /**
@@ -233,7 +229,7 @@ export function Markdown(options) {
     passNode: true
   })
 
-  /** @type {Visitor} */
+  /** @type {BuildVisitor<Root>} */
   function transform(node, index, parent) {
     if (node.type === 'raw' && parent && typeof index === 'number') {
       if (skipHtml) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,3 @@
-// Register `Raw` in tree:
-/// <reference types="mdast-util-to-hast" />
-
 /**
  * @import {Element, ElementContent, Nodes, Parents, Root} from 'hast'
  * @import {Components as JsxRuntimeComponents} from 'hast-util-to-jsx-runtime'

--- a/test.jsx
+++ b/test.jsx
@@ -1,7 +1,7 @@
 /* @jsxRuntime automatic @jsxImportSource react */
 /**
- * @typedef {import('hast').Root} Root
- * @typedef {import('react-markdown').ExtraProps} ExtraProps
+ * @import {Root} from 'hast'
+ * @import {ExtraProps} from 'react-markdown'
  */
 
 import assert from 'node:assert/strict'


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This replaces `@typedef` tags with `@import` where applicable. `@import` tags were introduced in TypeScript 5.5.

<!--do not edit: pr-->
