### PR TITLE
Replace `JSX` global with explicit `ReactElement`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 /**
  * @import {Element, ElementContent, Nodes, Parents, Root} from 'hast'
  * @import {Components as JsxRuntimeComponents} from 'hast-util-to-jsx-runtime'
+ * @import {ReactElement} from 'react'
  * @import {Options as RemarkRehypeOptions} from 'remark-rehype'
  * @import {BuildVisitor} from 'unist-util-visit'
  * @import {PluggableList} from 'unified'
@@ -134,7 +135,7 @@ const deprecations = [
  *
  * @param {Readonly<Options>} options
  *   Props.
- * @returns {JSX.Element}
+ * @returns {ReactElement}
  *   React element.
  */
 export function Markdown(options) {

--- a/test.jsx
+++ b/test.jsx
@@ -1,7 +1,7 @@
 /* @jsxRuntime automatic @jsxImportSource react */
 /**
  * @import {Root} from 'hast'
- * @import {ComponentProps} from 'react'
+ * @import {ComponentProps, ReactElement} from 'react'
  * @import {ExtraProps} from 'react-markdown'
  */
 
@@ -23,55 +23,55 @@ test('react-markdown', async function (t) {
   })
 
   await t.test('should work', function () {
-    assert.equal(asHtml(<Markdown children="a" />), '<p>a</p>')
+    assert.equal(renderToStaticMarkup(<Markdown children="a" />), '<p>a</p>')
   })
 
   await t.test('should throw w/ `source`', function () {
     assert.throws(function () {
       // @ts-expect-error: check how the runtime handles untyped `source`.
-      asHtml(<Markdown source="a" />)
+      renderToStaticMarkup(<Markdown source="a" />)
     }, /Unexpected `source` prop, use `children` instead/)
   })
 
   await t.test('should throw w/ non-string children (number)', function () {
     assert.throws(function () {
       // @ts-expect-error: check how the runtime handles invalid `children`.
-      asHtml(<Markdown children={1} />)
+      renderToStaticMarkup(<Markdown children={1} />)
     }, /Unexpected value `1` for `children` prop, expected `string`/)
   })
 
   await t.test('should throw w/ non-string children (boolean)', function () {
     assert.throws(function () {
       // @ts-expect-error: check how the runtime handles invalid `children`.
-      asHtml(<Markdown children={true} />)
+      renderToStaticMarkup(<Markdown children={true} />)
     }, /Unexpected value `true` for `children` prop, expected `string`/)
   })
 
   await t.test('should support `null` as children', function () {
-    assert.equal(asHtml(<Markdown children={null} />), '')
+    assert.equal(renderToStaticMarkup(<Markdown children={null} />), '')
   })
 
   await t.test('should support `undefined` as children', function () {
-    assert.equal(asHtml(<Markdown children={undefined} />), '')
+    assert.equal(renderToStaticMarkup(<Markdown children={undefined} />), '')
   })
 
   await t.test('should warn w/ `allowDangerousHtml`', function () {
     assert.throws(function () {
       // @ts-expect-error: check how the runtime handles deprecated `allowDangerousHtml`.
-      asHtml(<Markdown allowDangerousHtml />)
+      renderToStaticMarkup(<Markdown allowDangerousHtml />)
     }, /Unexpected `allowDangerousHtml` prop, remove it/)
   })
 
   await t.test('should support `className`', function () {
     assert.equal(
-      asHtml(<Markdown children="a" className="md" />),
+      renderToStaticMarkup(<Markdown children="a" className="md" />),
       '<div class="md"><p>a</p></div>'
     )
   })
 
   await t.test('should support `className` (if w/o root)', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown children={'a'} className="b" rehypePlugins={[plugin]} />
       ),
       '<div class="b"></div>'
@@ -90,43 +90,51 @@ test('react-markdown', async function (t) {
 
   await t.test('should support a block quote', function () {
     assert.equal(
-      asHtml(<Markdown children="> a" />),
+      renderToStaticMarkup(<Markdown children="> a" />),
       '<blockquote>\n<p>a</p>\n</blockquote>'
     )
   })
 
   await t.test('should support a break', function () {
-    assert.equal(asHtml(<Markdown children={'a\\\nb'} />), '<p>a<br/>\nb</p>')
+    assert.equal(
+      renderToStaticMarkup(<Markdown children={'a\\\nb'} />),
+      '<p>a<br/>\nb</p>'
+    )
   })
 
   await t.test('should support a code (block, flow; indented)', function () {
     assert.equal(
-      asHtml(<Markdown children="    a" />),
+      renderToStaticMarkup(<Markdown children="    a" />),
       '<pre><code>a\n</code></pre>'
     )
   })
 
   await t.test('should support a code (block, flow; fenced)', function () {
     assert.equal(
-      asHtml(<Markdown children={'```js\na\n```'} />),
+      renderToStaticMarkup(<Markdown children={'```js\na\n```'} />),
       '<pre><code class="language-js">a\n</code></pre>'
     )
   })
 
   await t.test('should support a delete (GFM)', function () {
     assert.equal(
-      asHtml(<Markdown children="~a~" remarkPlugins={[remarkGfm]} />),
+      renderToStaticMarkup(
+        <Markdown children="~a~" remarkPlugins={[remarkGfm]} />
+      ),
       '<p><del>a</del></p>'
     )
   })
 
   await t.test('should support an emphasis', function () {
-    assert.equal(asHtml(<Markdown children="*a*" />), '<p><em>a</em></p>')
+    assert.equal(
+      renderToStaticMarkup(<Markdown children="*a*" />),
+      '<p><em>a</em></p>'
+    )
   })
 
   await t.test('should support a footnote (GFM)', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown children={'a[^x]\n\n[^x]: y'} remarkPlugins={[remarkGfm]} />
       ),
       '<p>a<sup><a href="#user-content-fn-x" id="user-content-fnref-x" data-footnote-ref="true" aria-describedby="footnote-label">1</a></sup></p>\n<section data-footnotes="true" class="footnotes"><h2 class="sr-only" id="footnote-label">Footnotes</h2>\n<ol>\n<li id="user-content-fn-x">\n<p>y <a href="#user-content-fnref-x" data-footnote-backref="" aria-label="Back to reference 1" class="data-footnote-backref">↩</a></p>\n</li>\n</ol>\n</section>'
@@ -134,72 +142,80 @@ test('react-markdown', async function (t) {
   })
 
   await t.test('should support a heading', function () {
-    assert.equal(asHtml(<Markdown children="# a" />), '<h1>a</h1>')
+    assert.equal(
+      renderToStaticMarkup(<Markdown children="# a" />),
+      '<h1>a</h1>'
+    )
   })
 
   await t.test('should support an html (default)', function () {
     assert.equal(
-      asHtml(<Markdown children="<i>a</i>" />),
+      renderToStaticMarkup(<Markdown children="<i>a</i>" />),
       '<p>&lt;i&gt;a&lt;/i&gt;</p>'
     )
   })
 
   await t.test('should support an html (w/ `rehype-raw`)', function () {
     assert.equal(
-      asHtml(<Markdown children="<i>a</i>" rehypePlugins={[rehypeRaw]} />),
+      renderToStaticMarkup(
+        <Markdown children="<i>a</i>" rehypePlugins={[rehypeRaw]} />
+      ),
       '<p><i>a</i></p>'
     )
   })
 
   await t.test('should support an image', function () {
     assert.equal(
-      asHtml(<Markdown children="![a](b)" />),
+      renderToStaticMarkup(<Markdown children="![a](b)" />),
       '<p><img src="b" alt="a"/></p>'
     )
   })
 
   await t.test('should support an image w/ a title', function () {
     assert.equal(
-      asHtml(<Markdown children="![a](b (c))" />),
+      renderToStaticMarkup(<Markdown children="![a](b (c))" />),
       '<p><img src="b" alt="a" title="c"/></p>'
     )
   })
 
   await t.test('should support an image reference / definition', function () {
     assert.equal(
-      asHtml(<Markdown children={'![a]\n\n[a]: b'} />),
+      renderToStaticMarkup(<Markdown children={'![a]\n\n[a]: b'} />),
       '<p><img src="b" alt="a"/></p>'
     )
   })
 
   await t.test('should support code (text, inline)', function () {
-    assert.equal(asHtml(<Markdown children="`a`" />), '<p><code>a</code></p>')
+    assert.equal(
+      renderToStaticMarkup(<Markdown children="`a`" />),
+      '<p><code>a</code></p>'
+    )
   })
 
   await t.test('should support a link', function () {
     assert.equal(
-      asHtml(<Markdown children="[a](b)" />),
+      renderToStaticMarkup(<Markdown children="[a](b)" />),
       '<p><a href="b">a</a></p>'
     )
   })
 
   await t.test('should support a link w/ a title', function () {
     assert.equal(
-      asHtml(<Markdown children="[a](b (c))" />),
+      renderToStaticMarkup(<Markdown children="[a](b (c))" />),
       '<p><a href="b" title="c">a</a></p>'
     )
   })
 
   await t.test('should support a link reference / definition', function () {
     assert.equal(
-      asHtml(<Markdown children={'[a]\n\n[a]: b'} />),
+      renderToStaticMarkup(<Markdown children={'[a]\n\n[a]: b'} />),
       '<p><a href="b">a</a></p>'
     )
   })
 
   await t.test('should support prototype poluting identifiers', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={
             '[][__proto__] [][constructor]\n\n[__proto__]: a\n[constructor]: b'
@@ -212,36 +228,39 @@ test('react-markdown', async function (t) {
 
   await t.test('should support duplicate definitions', function () {
     assert.equal(
-      asHtml(<Markdown children={'[a][]\n\n[a]: b\n[a]: c'} />),
+      renderToStaticMarkup(<Markdown children={'[a][]\n\n[a]: b\n[a]: c'} />),
       '<p><a href="b">a</a></p>'
     )
   })
 
   await t.test('should support a list (unordered) / list item', function () {
-    assert.equal(asHtml(<Markdown children="* a" />), '<ul>\n<li>a</li>\n</ul>')
+    assert.equal(
+      renderToStaticMarkup(<Markdown children="* a" />),
+      '<ul>\n<li>a</li>\n</ul>'
+    )
   })
 
   await t.test('should support a list (ordered) / list item', function () {
     assert.equal(
-      asHtml(<Markdown children="1. a" />),
+      renderToStaticMarkup(<Markdown children="1. a" />),
       '<ol>\n<li>a</li>\n</ol>'
     )
   })
 
   await t.test('should support a paragraph', function () {
-    assert.equal(asHtml(<Markdown children="a" />), '<p>a</p>')
+    assert.equal(renderToStaticMarkup(<Markdown children="a" />), '<p>a</p>')
   })
 
   await t.test('should support a strong', function () {
     assert.equal(
-      asHtml(<Markdown children="**a**" />),
+      renderToStaticMarkup(<Markdown children="**a**" />),
       '<p><strong>a</strong></p>'
     )
   })
 
   await t.test('should support a table (GFM)', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={'| a |\n| - |\n| b |'}
           remarkPlugins={[remarkGfm]}
@@ -253,7 +272,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support a table (GFM; w/ align)', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={'| a | b | c | d |\n| :- | :-: | -: | - |'}
           remarkPlugins={[remarkGfm]}
@@ -264,86 +283,89 @@ test('react-markdown', async function (t) {
   })
 
   await t.test('should support a thematic break', function () {
-    assert.equal(asHtml(<Markdown children="***" />), '<hr/>')
+    assert.equal(renderToStaticMarkup(<Markdown children="***" />), '<hr/>')
   })
 
   await t.test('should support ab absolute path', function () {
     assert.equal(
-      asHtml(<Markdown children="[](/a)" />),
+      renderToStaticMarkup(<Markdown children="[](/a)" />),
       '<p><a href="/a"></a></p>'
     )
   })
 
   await t.test('should support an absolute URL', function () {
     assert.equal(
-      asHtml(<Markdown children="[](http://a.com)" />),
+      renderToStaticMarkup(<Markdown children="[](http://a.com)" />),
       '<p><a href="http://a.com"></a></p>'
     )
   })
 
   await t.test('should support a URL w/ uppercase protocol', function () {
     assert.equal(
-      asHtml(<Markdown children="[](HTTPS://A.COM)" />),
+      renderToStaticMarkup(<Markdown children="[](HTTPS://A.COM)" />),
       '<p><a href="HTTPS://A.COM"></a></p>'
     )
   })
 
   await t.test('should make a `javascript:` URL safe', function () {
     assert.equal(
-      asHtml(<Markdown children="[](javascript:alert(1))" />),
+      renderToStaticMarkup(<Markdown children="[](javascript:alert(1))" />),
       '<p><a href=""></a></p>'
     )
   })
 
   await t.test('should make a `vbscript:` URL safe', function () {
     assert.equal(
-      asHtml(<Markdown children="[](vbscript:alert(1))" />),
+      renderToStaticMarkup(<Markdown children="[](vbscript:alert(1))" />),
       '<p><a href=""></a></p>'
     )
   })
 
   await t.test('should make a `VBSCRIPT:` URL safe', function () {
     assert.equal(
-      asHtml(<Markdown children="[](VBSCRIPT:alert(1))" />),
+      renderToStaticMarkup(<Markdown children="[](VBSCRIPT:alert(1))" />),
       '<p><a href=""></a></p>'
     )
   })
 
   await t.test('should make a `file:` URL safe', function () {
     assert.equal(
-      asHtml(<Markdown children="[](file:///etc/passwd)" />),
+      renderToStaticMarkup(<Markdown children="[](file:///etc/passwd)" />),
       '<p><a href=""></a></p>'
     )
   })
 
   await t.test('should allow an empty URL', function () {
-    assert.equal(asHtml(<Markdown children="[]()" />), '<p><a href=""></a></p>')
+    assert.equal(
+      renderToStaticMarkup(<Markdown children="[]()" />),
+      '<p><a href=""></a></p>'
+    )
   })
 
   await t.test('should support search (`?`) in a URL', function () {
     assert.equal(
-      asHtml(<Markdown children="[](a?javascript:alert(1))" />),
+      renderToStaticMarkup(<Markdown children="[](a?javascript:alert(1))" />),
       '<p><a href="a?javascript:alert(1)"></a></p>'
     )
   })
 
   await t.test('should support hash (`&`) in a URL', function () {
     assert.equal(
-      asHtml(<Markdown children="[](a?b&c=d)" />),
+      renderToStaticMarkup(<Markdown children="[](a?b&c=d)" />),
       '<p><a href="a?b&amp;c=d"></a></p>'
     )
   })
 
   await t.test('should support hash (`#`) in a URL', function () {
     assert.equal(
-      asHtml(<Markdown children="[](a#javascript:alert(1))" />),
+      renderToStaticMarkup(<Markdown children="[](a#javascript:alert(1))" />),
       '<p><a href="a#javascript:alert(1)"></a></p>'
     )
   })
 
   await t.test('should support `urlTransform` (`href` on `a`)', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children="[a](https://b.com 'c')"
           urlTransform={function (url, key, node) {
@@ -360,7 +382,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support `urlTransform` w/ empty URLs', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children="[]()"
           urlTransform={function (url, key, node) {
@@ -377,7 +399,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support `urlTransform` (`src` on `img`)', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children="![a](https://b.com 'c')"
           urlTransform={function (url, key, node) {
@@ -393,7 +415,9 @@ test('react-markdown', async function (t) {
   })
 
   await t.test('should support `skipHtml`', function () {
-    const actual = asHtml(<Markdown children="a<i>b</i>c" skipHtml />)
+    const actual = renderToStaticMarkup(
+      <Markdown children="a<i>b</i>c" skipHtml />
+    )
     assert.equal(actual, '<p>abc</p>')
   })
 
@@ -401,7 +425,7 @@ test('react-markdown', async function (t) {
     'should support `allowedElements` (drop unlisted nodes)',
     function () {
       assert.equal(
-        asHtml(
+        renderToStaticMarkup(
           <Markdown
             children={'# *a*\n* b'}
             allowedElements={['h1', 'li', 'ul']}
@@ -414,7 +438,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support `allowedElements` as a function', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children="*a* **b**"
           allowElement={function (element) {
@@ -427,7 +451,9 @@ test('react-markdown', async function (t) {
   })
   await t.test('should support `disallowedElements`', function () {
     assert.equal(
-      asHtml(<Markdown children={'# *a*\n* b'} disallowedElements={['em']} />),
+      renderToStaticMarkup(
+        <Markdown children={'# *a*\n* b'} disallowedElements={['em']} />
+      ),
       '<h1></h1>\n<ul>\n<li>b</li>\n</ul>'
     )
   })
@@ -436,7 +462,7 @@ test('react-markdown', async function (t) {
     'should fail for both `allowedElements` and `disallowedElements`',
     function () {
       assert.throws(function () {
-        asHtml(
+        renderToStaticMarkup(
           <Markdown
             children=""
             allowedElements={['p']}
@@ -451,7 +477,7 @@ test('react-markdown', async function (t) {
     'should support `unwrapDisallowed` w/ `allowedElements`',
     function () {
       assert.equal(
-        asHtml(
+        renderToStaticMarkup(
           <Markdown
             children="# *a*"
             unwrapDisallowed
@@ -467,7 +493,7 @@ test('react-markdown', async function (t) {
     'should support `unwrapDisallowed` w/ `disallowedElements`',
     function () {
       assert.equal(
-        asHtml(
+        renderToStaticMarkup(
           <Markdown
             children="# *a*"
             unwrapDisallowed
@@ -481,7 +507,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support `remarkRehypeOptions`', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={'[^x]\n\n[^x]: a\n\n'}
           remarkPlugins={[remarkGfm]}
@@ -494,14 +520,14 @@ test('react-markdown', async function (t) {
 
   await t.test('should support `components`', function () {
     assert.equal(
-      asHtml(<Markdown children="# a" components={{h1: 'h2'}} />),
+      renderToStaticMarkup(<Markdown children="# a" components={{h1: 'h2'}} />),
       '<h2>a</h2>'
     )
   })
 
   await t.test('should support `components` as functions', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children="a"
           components={{
@@ -525,7 +551,7 @@ test('react-markdown', async function (t) {
     console.error = capture
 
     assert.throws(function () {
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children="# a"
           components={{
@@ -553,7 +579,7 @@ test('react-markdown', async function (t) {
     let calls = 0
 
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={'# a\n## b'}
           components={{h1: heading, h2: heading}}
@@ -579,7 +605,7 @@ test('react-markdown', async function (t) {
   await t.test('should support `components` (code)', function () {
     let calls = 0
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={'```\na\n```\n\n\tb\n\n`c`'}
           components={{
@@ -603,7 +629,7 @@ test('react-markdown', async function (t) {
     let calls = 0
 
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={'* [x] a\n1. b'}
           components={{
@@ -628,7 +654,7 @@ test('react-markdown', async function (t) {
     let calls = 0
 
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children="1. a"
           components={{
@@ -652,7 +678,7 @@ test('react-markdown', async function (t) {
     let calls = 0
 
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children="* a"
           components={{
@@ -676,7 +702,7 @@ test('react-markdown', async function (t) {
     let calls = 0
 
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={'|a|\n|-|\n|b|'}
           components={{
@@ -702,7 +728,7 @@ test('react-markdown', async function (t) {
     let thCalls = 0
 
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={'|a|\n|-|\n|b|'}
           components={{
@@ -734,7 +760,7 @@ test('react-markdown', async function (t) {
   await t.test('should pass `node` to components', function () {
     let calls = 0
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children="*a*"
           components={{
@@ -773,14 +799,16 @@ test('react-markdown', async function (t) {
 
   await t.test('should support plugins (`remark-gfm`)', function () {
     assert.equal(
-      asHtml(<Markdown children="a ~b~ c" remarkPlugins={[remarkGfm]} />),
+      renderToStaticMarkup(
+        <Markdown children="a ~b~ c" remarkPlugins={[remarkGfm]} />
+      ),
       '<p>a <del>b</del> c</p>'
     )
   })
 
   await t.test('should support plugins (`remark-toc`)', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={'# a\n## Contents\n## b\n### c\n## d'}
           remarkPlugins={[remarkToc]}
@@ -804,7 +832,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support aria properties', function () {
     assert.equal(
-      asHtml(<Markdown children="c" rehypePlugins={[plugin]} />),
+      renderToStaticMarkup(<Markdown children="c" rehypePlugins={[plugin]} />),
       '<input id="a" aria-describedby="b" required=""/><p>c</p>'
     )
 
@@ -826,7 +854,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support data properties', function () {
     assert.equal(
-      asHtml(<Markdown children="b" rehypePlugins={[plugin]} />),
+      renderToStaticMarkup(<Markdown children="b" rehypePlugins={[plugin]} />),
       '<i data-whatever="a"></i><p>b</p>'
     )
 
@@ -848,7 +876,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support comma separated properties', function () {
     assert.equal(
-      asHtml(<Markdown children="c" rehypePlugins={[plugin]} />),
+      renderToStaticMarkup(<Markdown children="c" rehypePlugins={[plugin]} />),
       '<i accept="a, b"></i><p>c</p>'
     )
 
@@ -870,7 +898,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support `style` properties', function () {
     assert.equal(
-      asHtml(<Markdown children="a" rehypePlugins={[plugin]} />),
+      renderToStaticMarkup(<Markdown children="a" rehypePlugins={[plugin]} />),
       '<i style="color:red;font-weight:bold"></i><p>a</p>'
     )
 
@@ -894,7 +922,9 @@ test('react-markdown', async function (t) {
     'should support `style` properties w/ vendor prefixes',
     function () {
       assert.equal(
-        asHtml(<Markdown children="a" rehypePlugins={[plugin]} />),
+        renderToStaticMarkup(
+          <Markdown children="a" rehypePlugins={[plugin]} />
+        ),
         '<i style="-ms-b:1;-webkit-c:2"></i><p>a</p>'
       )
 
@@ -917,7 +947,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support broken `style` properties', function () {
     assert.equal(
-      asHtml(<Markdown children="a" rehypePlugins={[plugin]} />),
+      renderToStaticMarkup(<Markdown children="a" rehypePlugins={[plugin]} />),
       '<i></i><p>a</p>'
     )
 
@@ -939,7 +969,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support SVG elements', function () {
     assert.equal(
-      asHtml(<Markdown children="a" rehypePlugins={[plugin]} />),
+      renderToStaticMarkup(<Markdown children="a" rehypePlugins={[plugin]} />),
       '<svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg"><title>SVG `&lt;circle&gt;` element</title><circle cx="120" cy="120" r="100"></circle><path stroke-miterlimit="-1"></path></svg><p>a</p>'
     )
 
@@ -984,7 +1014,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support comments (ignore them)', function () {
     const input = 'a'
-    const actual = asHtml(
+    const actual = renderToStaticMarkup(
       <Markdown children={input} rehypePlugins={[plugin]} />
     )
     const expected = '<p>a</p>'
@@ -1003,7 +1033,7 @@ test('react-markdown', async function (t) {
 
   await t.test('should support table cells w/ style', function () {
     assert.equal(
-      asHtml(
+      renderToStaticMarkup(
         <Markdown
           children={'| a  |\n| :- |'}
           remarkPlugins={[remarkGfm]}
@@ -1029,7 +1059,10 @@ test('react-markdown', async function (t) {
   })
 
   await t.test('should not fail on a plugin replacing `root`', function () {
-    assert.equal(asHtml(<Markdown children="a" rehypePlugins={[plugin]} />), '')
+    assert.equal(
+      renderToStaticMarkup(<Markdown children="a" rehypePlugins={[plugin]} />),
+      ''
+    )
 
     function plugin() {
       /**
@@ -1042,11 +1075,3 @@ test('react-markdown', async function (t) {
     }
   })
 })
-
-/**
- * @param {ReturnType<typeof Markdown>} input
- * @returns {string}
- */
-function asHtml(input) {
-  return renderToStaticMarkup(input)
-}

--- a/test.jsx
+++ b/test.jsx
@@ -1,6 +1,7 @@
 /* @jsxRuntime automatic @jsxImportSource react */
 /**
  * @import {Root} from 'hast'
+ * @import {ComponentProps} from 'react'
  * @import {ExtraProps} from 'react-markdown'
  */
 
@@ -564,7 +565,7 @@ test('react-markdown', async function (t) {
     assert.equal(calls, 2)
 
     /**
-     * @param {JSX.IntrinsicElements['h1'] & ExtraProps} props
+     * @param {ComponentProps<'h1'> & ExtraProps} props
      */
     function heading(props) {
       const {node, ...rest} = props


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This makes the `react-markdown` types compatible with React 19. Dependencies still rely on the `JSX` namespace, but let’s trackle one thing at a time.

The better return type would be `ReactNode`, not `ReactElement`. But that breaks compatibility with TypeScript < 5.1. Let’s do that in a semver major.

<!--do not edit: pr-->
