### PR TITLE
Leverage TypeScript project references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 coverage/
 node_modules/
 types/
-*.tsbuildinfo
 *.log
+*.tsbuildinfo
 .DS_Store
 react-markdown.min.js
 yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 coverage/
 node_modules/
-*.d.ts
+types/
+*.tsbuildinfo
 *.log
 .DS_Store
 react-markdown.min.js

--- a/index.js
+++ b/index.js
@@ -1,9 +1,0 @@
-/**
- * @typedef {import('hast-util-to-jsx-runtime').ExtraProps} ExtraProps
- * @typedef {import('./lib/index.js').AllowElement} AllowElement
- * @typedef {import('./lib/index.js').Components} Components
- * @typedef {import('./lib/index.js').Options} Options
- * @typedef {import('./lib/index.js').UrlTransform} UrlTransform
- */
-
-export {Markdown as default, defaultUrlTransform} from './lib/index.js'

--- a/lib/exports.ts
+++ b/lib/exports.ts
@@ -1,0 +1,9 @@
+export type {ExtraProps} from 'hast-util-to-jsx-runtime'
+export {
+  type AllowElement,
+  type Components,
+  type Options,
+  type UrlTransform,
+  defaultUrlTransform,
+  default
+} from './index.js'

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,7 +138,7 @@ const deprecations = [
  * @returns {ReactElement}
  *   React element.
  */
-export function Markdown(options) {
+export default function Markdown(options) {
   const allowedElements = options.allowedElements
   const allowElement = options.allowElement
   const children = options.children || ''

--- a/package.json
+++ b/package.json
@@ -69,11 +69,13 @@
   ],
   "sideEffects": false,
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    "types": "./types/exports.d.ts",
+    "default": "./lib/index.js"
+  },
   "files": [
     "lib/",
-    "index.d.ts",
-    "index.js"
+    "types/"
   ],
   "dependencies": {
     "@types/hast": "^3.0.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "customConditions": ["development"],
+    "exactOptionalPropertyTypes": true,
+    "module": "node16",
+    "strict": true,
+    "target": "es2022"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "lib": ["dom", "es2022"],
     "outDir": "types/",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "lib": ["dom", "es2022"],
+    "outDir": "types/",
+    "rootDir": "lib/",
+    "target": "es2022",
+    "types": []
+  },
+  "include": ["lib/"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,11 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "checkJs": true,
-    "customConditions": ["development"],
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "exactOptionalPropertyTypes": true,
     "jsx": "preserve",
-    "lib": ["dom", "es2022"],
-    "module": "node16",
-    "strict": true,
-    "target": "es2022"
+    "lib": ["es2022"],
+    "noEmit": true,
+    "types": ["node"]
   },
-  "exclude": ["coverage/", "node_modules/"],
-  "include": ["**/*.js", "**/*.jsx", "lib/complex-types.d.ts"]
+  "exclude": ["coverage/", "lib/", "node_modules/"],
+  "references": [{"path": "./tsconfig.build.json"}]
 }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This changes the TypeScript configuration of the project. It’s based on https://github.com/orgs/unifiedjs/discussions/238. The project now uses 2 TypeScript configurations: `tsconfig.json` and `tsconfig.build.json`. There’s also `tsconfig.base.json`. This is an implementation detail, it only exists so it can be extended from.

`tsconfig.build.json` is used to build the source files.

- It only includes the `lib` directory.
- It emits the type declarations into the `types` directory.
- It does not include the `node` types, meaning that importing Node.js builtins will cause the build to fail.
- It includes the `dom` lib, which is needed because of an upstream dependency.
- It does not allow the use of JSX.
- It includes a new file `lib/exports.ts`, which can be used to re-export additional types. This replaces the old `index.js` in the project root, which `@typedef` tags to mimic type exports.

`tsconfig.json` is used to typecheck the rest of the project.

- It excludes the `lib` directory.
- It does **not** emit type declarations.
- It includes the `node` types, meaning we can import Node.js builtins (such as `node:test`)
- It does **not** include the `dom` types, meaning we can’t use browser globals there.
- It builds `tsconfig.build.json` first, based on `references`.
- It type checks the `types` directory emitted by `tsconfig.build.json`. We have run into JSDoc specific emit issues before, so this is really nice to have.

To build or rebuild the project, we can now run either `tsc --build` or `tsc --build --force`. This correctly uses incremental builds, so a second run of `tsc --build` is faster.

Without this PR, after building, we have type errors in our editor. This is now solved.

![Errors in tsconfig.json](https://github.com/remarkjs/react-markdown/assets/779047/2ab5056a-7515-4e5e-b77b-86fd9de8d7f1)

Variations of this are possible. The main point is:

- Separate JavaScript source files from other JavaScript files.
- Use separate configurations for different environments/purposes. This is even more apparent for mono repos that target different conflicting environments. (I have a commit ready for https://github.com/mdx-js/mdx, but wanted to discuss this in a simpler repo first.)
- Use `rootDir` and `outDir`.
- Avoid writing `.d.ts` files.
- Use `.ts` files to write TypeScript things that are not possible with types in JSDoc.

An interesting idea that builds on this, is to move type definitions from `@typedef` tags into TypeScript files.

<!--do not edit: pr-->
