### PR TITLE
zh-CN localization for gh-page

### DIFF
--- a/src/zh-cn/index.css
+++ b/src/zh-cn/index.css
@@ -1,0 +1,186 @@
+:root {
+  --ff-sans: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Noto Sans',
+    'Helvetica', 'Arial', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --ff-mono: ui-monospace, 'SFMono-Regular', 'SF Mono', 'Menlo', 'Consolas',
+    'Liberation Mono', monospace;
+  --color-canvas-back: #f6f8fa;
+  --color-hl: #0969da;
+  --color-fg: #0d1117;
+
+  color-scheme: light dark;
+  background-color: var(--color-canvas-back);
+  color: var(--color-fg);
+  font-family: var(--ff-sans);
+  font-kerning: normal;
+  font-feature-settings: 'kern', 'liga', 'clig', 'calt';
+  text-size-adjust: 100%;
+  word-break: break-word;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-canvas-back: #0d1117;
+    --color-hl: #58a6ff;
+    --color-fg: #f6f8fa;
+  }
+}
+
+body {
+  margin: 0;
+
+  /* background-color: var(--color-canvas-back); */
+
+  /* color: var(--color-fg); */
+}
+
+* {
+  line-height: calc(1 * (1em + 1ex));
+  box-sizing: border-box;
+}
+
+code,
+kbd,
+pre,
+textarea,
+.write,
+.draw {
+  font-family: var(--ff-mono);
+  font-feature-settings: normal;
+  font-size: smaller;
+}
+
+.page-header {
+  font-size: inherit;
+  margin: calc(1 * (1em + 1ex));
+}
+
+.editor,
+.result {
+  position: fixed;
+  top: calc(3 * (1em + 1ex));
+  bottom: 0;
+  overflow: auto;
+}
+
+.editor {
+  left: 0;
+  width: 50%;
+}
+
+.result {
+  right: 0;
+  left: 50%;
+  padding: calc(1em + 1ex);
+}
+
+.editor-inner {
+  position: relative;
+  max-width: 100%;
+  overflow: hidden;
+  margin: 8px;
+}
+
+.write,
+.draw {
+  font-size: 14px;
+  tab-size: 4;
+  letter-spacing: normal;
+  line-height: calc(1 * (1em + 1ex));
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  background: transparent;
+  box-sizing: border-box;
+  border: none;
+  outline: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  resize: none;
+}
+
+.write::selection {
+  color: var(--color-fg);
+  background-color: hsl(42.22deg 74.31% 57.25% / 66%);
+}
+
+.write {
+  position: absolute;
+  top: 0;
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+  color: transparent;
+  caret-color: var(--color-hl);
+}
+
+.controls {
+  color: var(--color-fg);
+  background-color: var(--color-canvas-back);
+  padding: calc(1ex);
+  padding-top: 0;
+}
+
+.controls label {
+  font-size: smaller;
+  display: block;
+}
+
+.github-corner svg {
+  z-index: 1;
+  width: calc(6.5 * (1em + 1ex));
+  height: calc(6.5 * (1em + 1ex));
+}
+
+.github-corner:hover .octo-arm {
+  animation: octocat-wave 560ms ease-in-out;
+}
+
+.show-big {
+  display: none;
+}
+
+@keyframes octocat-wave {
+  0%,
+  100% {
+    transform: rotate(0);
+  }
+
+  20%,
+  60% {
+    transform: rotate(-25deg);
+  }
+
+  40%,
+  80% {
+    transform: rotate(10deg);
+  }
+}
+
+@media (width <= 40em) {
+  .github-corner .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
+  }
+
+  .github-corner:hover .octo-arm {
+    animation: none;
+  }
+}
+
+@media (width >= 40em) {
+  html {
+    font-size: 1.125em;
+  }
+
+  .controls {
+    position: fixed;
+    top: calc(3 * (1em + 1ex));
+    right: 50%;
+    z-index: 4;
+    border-bottom-left-radius: 1ex;
+  }
+
+  .show-big {
+    display: initial;
+  }
+}

--- a/src/zh-cn/index.html
+++ b/src/zh-cn/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang=en>
+<meta charset=utf8>
+<title>react-markdown</title>
+<meta property=og:title content=react-markdown>
+<meta name=viewport content=width=device-width,initial-scale=1>
+<meta name=description content="适用于React的Markdown插件">
+<meta property=og:description content="适用于React的Markdown插件">
+<link rel=stylesheet href=https://esm.sh/@wooorm/starry-night@3/style/both.css>
+<link rel=stylesheet href=https://esm.sh/github-markdown-css@5/github-markdown.css>
+<!-- To do: remove when `react-markdown` supports async plugins and we can use starry-night -->
+<link rel=stylesheet href=https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github.min.css>
+<link rel=stylesheet href=index.css>
+<a href=https://github.com/remarkjs/react-markdown class=github-corner aria-label="在GitHub查看该项目">
+  <svg
+    viewBox="0 0 250 250"
+    style=fill:#1b1f23;color:#fafbfc;position:absolute;top:0;border:0;right:0
+    aria-hidden=true
+  >
+    <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"/>
+    <path
+      d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+      fill=currentColor
+      style="transform-origin:130px 106px;"
+      class=octo-arm
+    />
+    <path
+      d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+      fill=currentColor
+      class=octo-body
+    />
+  </svg>
+</a>
+<div class=container>
+  <h1 class=page-header>中文 | react-markdown</h1>
+  <main></main>
+</div>
+<script type=module src=index.module.js></script>
+<script nomodule src=index.nomodule.js></script>

--- a/src/zh-cn/index.js
+++ b/src/zh-cn/index.js
@@ -1,0 +1,258 @@
+/**
+ * @typedef {import('@wooorm/starry-night').Grammar} Grammar
+ * @typedef {import('unified').PluggableList} PluggableList
+ */
+
+import {createStarryNight} from '@wooorm/starry-night'
+import sourceCss from '@wooorm/starry-night/source.css'
+import sourceJs from '@wooorm/starry-night/source.js'
+import sourceTs from '@wooorm/starry-night/source.ts'
+import sourceTsx from '@wooorm/starry-night/source.tsx'
+import textHtmlBasic from '@wooorm/starry-night/text.html.basic'
+import textMd from '@wooorm/starry-night/text.md'
+import {toJsxRuntime} from 'hast-util-to-jsx-runtime'
+import React from 'react'
+// @ts-expect-error: untyped.
+import {Fragment, jsx, jsxs} from 'react/jsx-runtime'
+import ReactDom from 'react-dom/client'
+import Markdown from 'react-markdown'
+// To do: replace with `starry-night` when async plugins are supported.
+import rehypeHighlight from 'rehype-highlight'
+import rehypeRaw from 'rehype-raw'
+import rehypeSlug from 'rehype-slug'
+import remarkGfm from 'remark-gfm'
+import remarkToc from 'remark-toc'
+
+/** @type {ReadonlyArray<Grammar>} */
+const grammars = [
+  sourceCss,
+  sourceJs,
+  sourceTs,
+  sourceTsx,
+  textHtmlBasic,
+  textMd
+]
+
+const sample = `# \`react-markdown\` 的演示页面
+
+\`react-markdown\` 是React的一个Markdown组件.
+
+👉 修改这边的文本可以在右边实时渲染.
+
+👈 在左侧写入一些markdown语句试试吧！
+
+## 摘要
+
+* 本项目遵循 [CommonMark](https://commonmark.org)
+* （可选）本项目遵循 [GitHub Flavored Markdown](https://github.github.com/gfm/)
+* Markdown是被实时渲染成react元素的，并没有使用 \`dangerouslySetInnerHTML\`
+* 允许您定义自己的组件，比如\`<MyHeading>\`而不是强制使用\`<'h1'>\`)
+* 多种可选插件
+
+## 内容
+
+插件的演示范例
+([\`remark-toc\`](https://github.com/remarkjs/remark-toc)).
+**这里将会被替换成实际目录**.
+
+## 语法高亮使用
+
+下面是一个代码高亮的插件:
+[\`rehype-highlight\`](https://github.com/rehypejs/rehype-highlight).
+
+\`\`\`js
+import React from 'react'
+import ReactDOM from 'react-dom'
+import Markdown from 'react-markdown'
+import rehypeHighlight from 'rehype-highlight'
+
+const markdown = \`
+# Your markdown here
+\`
+
+ReactDOM.render(
+  <Markdown rehypePlugins={[rehypeHighlight]}>{markdown}</Markdown>,
+  document.querySelector('#content')
+)
+\`\`\`
+
+很简洁，不是吗？
+
+## GitHub 风格的 Markdown (GFM)
+
+你 *也可以* 使用
+[\`remark-gfm\`](https://github.com/remarkjs/react-markdown#use)来使用GFM, .
+这个插件支持GitHub特有的makrdown方法，包括但不限于：
+表格, 删除线, 任务列表 和 文本链接.
+
+**默认情况下，**这些插件不会自动启用.
+👆 往上看，看到上方的\`勾选启用GFM\`了吗？勾选将其打开.
+
+| 功能       | 支持程度              |
+| ---------: | :------------------- |
+| CommonMark | 100%                 |
+| GFM        | 100% w/ \`remark-gfm\` |
+
+~~删除线~~
+
+* [ ] 任务列表
+* [x] 任务列表（已勾选）
+
+https://example.com
+
+## 在markdown重嵌入html代码
+
+⚠️ **警告！警告！警告！** 在markdown重嵌入html代码是一种**非常不安全的行为**,但如果你坚持想使用html, 你可以
+使用 [\`rehype-raw\`](https://github.com/rehypejs/rehype-raw)这个插件.
+你也可以将其与
+[\`rehype-sanitize\`](https://github.com/rehypejs/rehype-sanitize)相结合.
+
+<blockquote>
+  👆 往上看，看到上方的\`勾选启用Html\`了吗？勾选将其打开.
+</blockquote>
+
+## 组件
+
+您可以通过传递组件来更改内容:
+
+\`\`\`js
+import React from 'react'
+import ReactDOM from 'react-dom'
+import Markdown from 'react-markdown'
+import MyFancyRule from './components/my-fancy-rule.js'
+
+const markdown = \`
+# 在这里写入你的markdown代码
+\`
+
+ReactDOM.render(
+  <Markdown
+    components={{
+      // 用h2标签代替h1标签
+      h1: 'h2',
+      // 用一个组件代替hr
+      hr(props) {
+        const {node, ...rest} = props
+        return <MyFancyRule {...rest} />
+      }
+    }}
+  >
+    {markdown}
+  </Markdown>,
+  document.querySelector('#content')
+)
+\`\`\`
+
+## 了解更多
+
+更多信息请访问GitHub项目的
+[readme.md](https://github.com/remarkjs/react-markdown)!
+
+***
+
+[Espen Hovlandsdal](https://espen.codes/)的一个组件`
+
+const main = document.querySelectorAll('main')[0]
+const root = ReactDom.createRoot(main)
+
+/** @type {Awaited<ReturnType<typeof createStarryNight>>} */
+let starryNight
+
+// eslint-disable-next-line unicorn/prefer-top-level-await -- XO is wrong.
+createStarryNight(grammars).then(
+  /**
+   * @returns {undefined}
+   */
+  function (x) {
+    starryNight = x
+
+    const missing = starryNight.missingScopes()
+    if (missing.length > 0) {
+      throw new Error('Missing scopes: `' + missing + '`')
+    }
+
+    root.render(React.createElement(Playground))
+  }
+)
+
+function Playground() {
+  const [text, setText] = React.useState(sample)
+  const [gfm, setGfm] = React.useState(false)
+  const [raw, setRaw] = React.useState(false)
+  /** @type {PluggableList} */
+  const rehypePlugins = [rehypeSlug, rehypeHighlight]
+  /** @type {PluggableList} */
+  const remarkPlugins = [remarkToc]
+
+  if (gfm) {
+    remarkPlugins.unshift(remarkGfm)
+  }
+
+  if (raw) {
+    rehypePlugins.unshift(rehypeRaw)
+  }
+
+  return (
+    <>
+      <form className="editor">
+        <div className="controls">
+          <label>
+            <input
+              type="checkbox"
+              name="gfm"
+              checked={gfm}
+              onChange={function () {
+                setGfm(!gfm)
+              }}
+            />{' '}
+            勾选启用 <code>remark-gfm</code>
+            <span className="show-big"> GFM</span>
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              name="raw"
+              checked={raw}
+              onChange={function () {
+                setRaw(!raw)
+              }}
+            />{' '}
+            勾选启用 <code>rehype-raw</code>
+            <span className="show-big"> HTML</span>
+          </label>
+        </div>
+        <div className="editor-inner">
+          <div className="draw">
+            {toJsxRuntime(starryNight.highlight(text, 'text.md'), {
+              Fragment,
+              jsx,
+              jsxs
+            })}
+            {/* Trailing whitespace in a `textarea` is shown, but not in a `div`
+          with `white-space: pre-wrap`.
+          Add a `br` to make the last newline explicit. */}
+            {/\n[ \t]*$/.test(text) ? <br /> : undefined}
+          </div>
+          <textarea
+            spellCheck="false"
+            className="write"
+            value={text}
+            rows={text.split('\n').length + 1}
+            onChange={function (event) {
+              setText(event.target.value)
+            }}
+          />
+        </div>
+      </form>
+      <div className="result">
+        <Markdown
+          className="markdown-body"
+          remarkPlugins={remarkPlugins}
+          rehypePlugins={rehypePlugins}
+        >
+          {text}
+        </Markdown>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

TODO
added zh-CN translation in src/zh-cn for gh-page

<!--do not edit: pr-->
