### PR TITLE
Fixing `string[]` scenario

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,8 +162,10 @@ export function Markdown(options) {
 
   const file = new VFile()
 
-  if (typeof children === 'string') {
-    file.value = children
+  const allChildrenAreStrings = Array.isArray(children) ? children.every((child) => typeof child === 'string') : typeof children === 'string';
+
+  if (allChildrenAreStrings) {
+    file.value = Array.isArray(children) ? children.join('\n') : children
   } else {
     unreachable(
       'Unexpected value `' +

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@
  * @property {ReadonlyArray<string> | null | undefined} [allowedElements]
  *   Tag names to allow (default: all tag names);
  *   cannot combine w/ `disallowedElements`.
- * @property {string | null | undefined} [children]
+ * @property {string | null | undefined | string[]} [children]
  *   Markdown.
  * @property {string | null | undefined} [className]
  *   Wrap in a `div` with this class name.
@@ -162,7 +162,9 @@ export function Markdown(options) {
 
   const file = new VFile()
 
-  const allChildrenAreStrings = Array.isArray(children) ? children.every((child) => typeof child === 'string') : typeof children === 'string';
+  const allChildrenAreStrings = Array.isArray(children)
+    ? children.every((child) => typeof child === 'string')
+    : typeof children === 'string'
 
   if (allChildrenAreStrings) {
     file.value = Array.isArray(children) ? children.join('\n') : children

--- a/test.jsx
+++ b/test.jsx
@@ -55,6 +55,10 @@ test('react-markdown', async function (t) {
     assert.equal(renderToStaticMarkup(<Markdown children={undefined} />), '')
   })
 
+  await t.test('should support `string[]` as children', function () {
+    assert.equal(renderToStaticMarkup(<Markdown children={['']} />), '')
+  })
+
   await t.test('should warn w/ `allowDangerousHtml`', function () {
     assert.throws(function () {
       // @ts-expect-error: check how the runtime handles deprecated `allowDangerousHtml`.


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This addresses issue #854 by adding support for `string[]` in addition to `string` children.

<!--do not edit: pr-->
