### PR TITLE
Fix Object.hasOwn is not a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,6 +162,11 @@ export function Markdown(options) {
 
   const file = new VFile()
 
+  if (!Object.hasOwn) {
+  Object.hasOwn = (obj, prop) =>
+    Object.prototype.hasOwnProperty.call(obj, prop);
+  }
+
   if (typeof children === 'string') {
     file.value = children
   } else {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

To support old version of browser, add the polyfill of Object.hasOwn.
About Object.hasOwn browser compatibility: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn#browser_compatibility

<!--do not edit: pr-->
