### PR TITLE
Separate all typedefs into their own JSDoc blocks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,10 +18,14 @@
  *   Parent of `element`.
  * @returns {boolean | null | undefined}
  *   Whether to allow `element` (default: `false`).
- *
+ */
+
+/**
  * @typedef {Partial<JsxRuntimeComponents>} Components
  *   Map tag names to components.
- *
+ */
+
+/**
  * @typedef Deprecation
  *   Deprecation.
  * @property {string} from
@@ -30,7 +34,9 @@
  *   ID in readme.
  * @property {keyof Options} [to]
  *   New field.
- *
+ */
+
+/**
  * @typedef Options
  *   Configuration.
  * @property {AllowElement | null | undefined} [allowElement]
@@ -62,7 +68,9 @@
  *   with `unwrapDisallowed` the element itself is replaced by its children.
  * @property {UrlTransform | null | undefined} [urlTransform]
  *   Change URLs (default: `defaultUrlTransform`)
- *
+ */
+
+/**
  * @callback UrlTransform
  *   Transform all URLs.
  * @param {string} url


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This change separates all typedefs into their own JSDoc blocks. Having them in the same block, can be problematic sometimes. For example when they contain `@template` tags.

<!--do not edit: pr-->
