### PR TITLE
Add support for React 19

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /**
- * @typedef {import('hast-util-to-jsx-runtime').ExtraProps} ExtraProps
  * @typedef {import('./lib/index.js').AllowElement} AllowElement
  * @typedef {import('./lib/index.js').Components} Components
+ * @typedef {import('./lib/index.js').ExtraProps} ExtraProps
  * @typedef {import('./lib/index.js').Options} Options
  * @typedef {import('./lib/index.js').UrlTransform} UrlTransform
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 /**
  * @import {Element, ElementContent, Nodes, Parents, Root} from 'hast'
- * @import {Components as JsxRuntimeComponents} from 'hast-util-to-jsx-runtime'
- * @import {ReactElement} from 'react'
+ * @import {ComponentProps, ElementType, ReactElement} from 'react'
  * @import {Options as RemarkRehypeOptions} from 'remark-rehype'
  * @import {BuildVisitor} from 'unist-util-visit'
  * @import {PluggableList} from 'unified'
@@ -21,7 +20,16 @@
  */
 
 /**
- * @typedef {Partial<JsxRuntimeComponents>} Components
+ * @typedef ExtraProps
+ *   Extra fields we pass.
+ * @property {Element | undefined} [node]
+ *   passed when `passNode` is on.
+ */
+
+/**
+ * @typedef {{
+ *   [Key in Extract<ElementType, string>]?: ElementType<ComponentProps<Key> & ExtraProps>
+ * }} Components
  *   Map tag names to components.
  */
 
@@ -225,6 +233,9 @@ export function Markdown(options) {
 
   return toJsxRuntime(hastTree, {
     Fragment,
+    // @ts-expect-error
+    // React components are allowed to return numbers,
+    // but not according to the types in hast-util-to-jsx-runtime
     components,
     ignoreInvalidStyle: true,
     jsx,


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This adds support for React 19 types, by removing the dependency on the types provided by hast-util-to-jsx-runtime, thus removing the dependency on the JSX global namespace.

Unfortunately the current setup doesn’t really allow testing the types against multiple React versions. #838 would enable that.

Closes #877

<!--do not edit: pr-->
