### PR TITLE
Optimize the Components type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * @import {Element, Nodes, Parents, Root} from 'hast'
  * @import {Root as MdastRoot} from 'mdast'
- * @import {ComponentProps, ElementType, ReactElement} from 'react'
+ * @import {ComponentType, JSX, ReactElement} from 'react'
  * @import {Options as RemarkRehypeOptions} from 'remark-rehype'
  * @import {BuildVisitor} from 'unist-util-visit'
  * @import {PluggableList, Processor} from 'unified'
@@ -29,7 +29,7 @@
 
 /**
  * @typedef {{
- *   [Key in Extract<ElementType, string>]?: ElementType<ComponentProps<Key> & ExtraProps>
+ *   [Key in keyof JSX.IntrinsicElements]?: ComponentType<JSX.IntrinsicElements[Key] & ExtraProps> | keyof JSX.IntrinsicElements
  * }} Components
  *   Map tag names to components.
  */


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

The way we used `ElementType` caused a significant increase of resource usage for TypeScript.

I can’t really explain it, but this fixes it. I’m personally inclined to say people should avoid using the `JSX` namespace, but I see no other way around it.

Without this change, autocompletion in my editor takes a noticable time to load. Now it’s instant.

On my machine this halves the time of running `tsc -b` from ~15s to ~7s.

Closes #883

<!--do not edit: pr-->
