### PR TITLE
Add lifecycle tests for MarkdownHooks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -206,7 +206,6 @@ export function MarkdownHooks(options) {
   const [tree, setTree] = useState(/** @type {Root | undefined} */ (undefined))
 
   useEffect(
-    /* c8 ignore next 7 -- hooks are client-only. */
     function () {
       const file = createFile(options)
       processor.run(processor.parse(file), file, function (error, tree) {
@@ -222,10 +221,8 @@ export function MarkdownHooks(options) {
     ]
   )
 
-  /* c8 ignore next -- hooks are client-only. */
   if (error) throw error
 
-  /* c8 ignore next -- hooks are client-only. */
   return tree ? post(tree, options) : createElement(Fragment)
 }
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "description": "React component to render markdown",
   "devDependencies": {
+    "@testing-library/react": "^16.0.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -69,6 +70,7 @@
     "concat-stream": "^2.0.0",
     "esbuild": "^0.25.0",
     "eslint-plugin-react": "^7.0.0",
+    "global-jsdom": "^26.0.0",
     "prettier": "^3.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This uses React Testing Library to test the hooks implementation. This gives us control over the React lifecycle, so we can test any state the component might be in.

<!--do not edit: pr-->
