### PR TITLE
Handle race conditions in MarkdownHooks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -207,11 +207,18 @@ export function MarkdownHooks(options) {
 
   useEffect(
     function () {
+      let cancelled = false
       const file = createFile(options)
       processor.run(processor.parse(file), file, function (error, tree) {
-        setError(error)
-        setTree(tree)
+        if (!cancelled) {
+          setError(error)
+          setTree(tree)
+        }
       })
+
+      return () => {
+        cancelled = true
+      }
     },
     [
       options.children,

--- a/test.jsx
+++ b/test.jsx
@@ -1165,6 +1165,27 @@ test('MarkdownHooks', async function (t) {
     })
     assert.equal(container.innerHTML, 'Error: rejected')
   })
+
+  await t.test('should support `MarkdownHooks` rerenders', async function () {
+    const pluginA = deferPlugin()
+    const pluginB = deferPlugin()
+
+    const result = render(
+      <MarkdownHooks children={'a'} rehypePlugins={[pluginA.plugin]} />
+    )
+
+    result.rerender(
+      <MarkdownHooks children={'b'} rehypePlugins={[pluginB.plugin]} />
+    )
+
+    assert.equal(result.container.innerHTML, '')
+    pluginB.resolve()
+    pluginA.resolve()
+    await waitFor(() => {
+      assert.notEqual(result.container.innerHTML, '')
+    })
+    assert.equal(result.container.innerHTML, '<p>b</p>')
+  })
 })
 
 /**


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Running asynchronous code inside a `useEffect` causes race conditions. This is now handled correctly.

<!--do not edit: pr-->
