### PR TITLE
Memoize the processor in MarkdownHooks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -213,7 +213,9 @@ export async function MarkdownAsync(options) {
  */
 export function MarkdownHooks(options) {
   const processor = useMemo(
-    () => createProcessor(options),
+    function () {
+      return createProcessor(options)
+    },
     [options.rehypePlugins, options.remarkPlugins, options.remarkRehypeOptions]
   )
   const [error, setError] = useState(

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,7 +107,7 @@ import {unreachable} from 'devlop'
 import {toJsxRuntime} from 'hast-util-to-jsx-runtime'
 import {urlAttributes} from 'html-url-attributes'
 import {Fragment, jsx, jsxs} from 'react/jsx-runtime'
-import {useEffect, useState} from 'react'
+import {useEffect, useMemo, useState} from 'react'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import {unified} from 'unified'
@@ -212,7 +212,10 @@ export async function MarkdownAsync(options) {
  *   React node.
  */
 export function MarkdownHooks(options) {
-  const processor = createProcessor(options)
+  const processor = useMemo(
+    () => createProcessor(options),
+    [options.rehypePlugins, options.remarkPlugins, options.remarkRehypeOptions]
+  )
   const [error, setError] = useState(
     /** @type {Error | undefined} */ (undefined)
   )
@@ -238,12 +241,7 @@ export function MarkdownHooks(options) {
         cancelled = true
       }
     },
-    [
-      options.children,
-      options.rehypePlugins,
-      options.remarkPlugins,
-      options.remarkRehypeOptions
-    ]
+    [options.children, processor]
   )
 
   if (error) throw error


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Some plugins may perform heavy work in preparation to make the transformer light-weight. A good example of this is `rehype-starry-night`.

Without this change, an interactive markdown editor which includes `rehype-starry-night` is very sluggish. With this change, performance is as good as if `rehype-starry-night` isn’t even used.

Fix https://github.com/orgs/rehypejs/discussions/194

<!--do not edit: pr-->
