### PR TITLE
Remove unused args in urlTransform

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -379,7 +379,7 @@ function post(tree, options) {
           const value = node.properties[key]
           const test = urlAttributes[key]
           if (test === null || test.includes(node.tagName)) {
-            node.properties[key] = urlTransform(String(value || ''), key, node)
+            node.properties[key] = urlTransform(String(value || ''))
           }
         }
       }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->


### Initial checklist

* [ x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x ] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [ x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [ x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x ] I made sure the docs are up to date
* [ x] I included tests (or that’s not needed)

### Description of changes

This PR removes the unused args when calling `urlTransform`. 

<!--do not edit: pr-->
