### PR TITLE
chore: add react native remark link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -810,8 +810,8 @@ It lets you define your own schema of what is and isn’t allowed.
   — hook based alternative
 * [`rehype-react`][github-rehype-react]
   — turn HTML into React elements
-* [`react-native-remark`][github-react-native-remark]
-  - remark on React Native
+* [`react-native-remark`][github-react-native-remark] 
+  — remark on React Native
 
 ## Contribute
 

--- a/readme.md
+++ b/readme.md
@@ -810,6 +810,8 @@ It lets you define your own schema of what is and isn’t allowed.
   — hook based alternative
 * [`rehype-react`][github-rehype-react]
   — turn HTML into React elements
+* [`react-native-remark`][github-react-native-remark]
+  - remark on React Native
 
 ## Contribute
 
@@ -902,6 +904,8 @@ abide by its terms.
 [github-rehype-raw]: https://github.com/rehypejs/rehype-raw
 
 [github-rehype-react]: https://github.com/rehypejs/rehype-react
+
+[github-react-native-remark]: https://github.com/imwithye/react-native-remark
 
 [github-rehype-sanitize]: https://github.com/rehypejs/rehype-sanitize
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Add related link to react-native-remark. I believe many developers are looking for a good solution for using remark with React Native, but existing options are limited. I created a library to fill this gap, and I think it would be helpful to include it as a related link. Thank you!

<!--do not edit: pr-->
